### PR TITLE
use external version of static by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ needs of other departments overlap with HMRC.
    ./startup.sh
    ````
 
+To run against a local version of static you need to set `STATIC_DEV` to "http://static.dev.gov.uk"
+
 ## Development notes
 
 * ```app/tasks``` - contains one-off tasks that can be run via console or a rake task.

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -6,6 +6,6 @@ HmrcContacts::Application.configure do
   end
 
   if Rails.env.development?
-    config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
+    config.slimmer.asset_host = ENV["STATIC_DEV"] || "https://static.preview.alphagov.co.uk"
   end
 end


### PR DESCRIPTION
Mainly for ie testing in browstack
