### PR TITLE
Remove contacts on delete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'plek', '>= 1.0.0'
 gem 'aws-ses', require: 'aws/ses' # Needed by exception_notification
 gem 'exception_notification'
 
+gem 'whenever'
+
 # assets
 gem 'sass-rails', '~> 4.0.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.9.1)
     ci_reporter (1.9.0)
       builder (>= 2.1.2)
     coderay (1.0.9)
@@ -273,6 +274,9 @@ GEM
       descendants_tracker (~> 0.0.1)
     warden (1.2.3)
       rack (>= 1.0)
+    whenever (0.8.2)
+      activesupport (>= 2.3.4)
+      chronic (>= 0.6.3)
     xml-simple (1.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -318,3 +322,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.6.3)
   virtus
+  whenever

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -20,9 +20,12 @@ module Admin
     end
 
     def destroy
-      contact.destroy
-
-      redirect_to admin_contacts_path, notice: 'Contact was successfully deleted'
+      if Admin::DestroyContact.new(contact).destroy
+        flash.notice = 'Contact successfully deleted'
+      else
+        flash.alert = 'There was an error deleting this contact, please try again later'
+      end
+      redirect_to admin_contacts_path
     end
 
     private

--- a/app/interactors/admin/destroy_contact.rb
+++ b/app/interactors/admin/destroy_contact.rb
@@ -1,0 +1,18 @@
+module Admin
+  class DestroyContact
+    include ::Contacts::Interactor
+
+    takes(:contact)
+
+    def destroy
+      begin
+        @contact.transaction do
+          RUMMAGER_INDEX.delete(@contact.slug)
+          @contact.destroy
+        end
+      rescue RestClient::RequestFailed, RestClient::RequestTimeout, RestClient::ServerBrokeConnection
+        false
+      end
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -30,11 +30,15 @@ class Contact < ActiveRecord::Base
     title
   end
 
+  def link
+    "/#{APP_SLUG}/#{department.slug}/#{self.slug}"
+  end
+
   def to_indexed_json
     {
       title: title,
       description: description,
-      link: "/#{APP_SLUG}/#{department.slug}/#{self.slug}",
+      link: link,
       format: "contact",
       indexable_content: "#{title} #{description} #{questions.map(&:title).join}"
     }

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,9 @@
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+
+# We need Rake to use our own environment
+job_type :rake, "cd :path && govuk_setenv contacts bundle exec rake :task --silent :output"
+
+every :hour do
+  rake "contacts:index"
+end

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -8,8 +8,7 @@ namespace :contacts do
 
   desc "Index Contacts & Questions in rummager"
   task index: :environment do
-    index = RUMMAGER_INDEX
-    index.add_batch Contact.includes(:contact_group, :questions, :department).all.map(&:to_indexed_json)
-    index.commit
+    RUMMAGER_INDEX.add_batch Contact.includes(:contact_group, :questions, :department).all.map(&:to_indexed_json)
+    RUMMAGER_INDEX.commit
   end
 end

--- a/spec/features/admin/contact_removal_spec.rb
+++ b/spec/features/admin/contact_removal_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'Contact removal', auth: :user do
+  include Admin::ContactSteps
+
+  let!(:contact) { create :contact }
+
+  before { verify contact_exists(contact) }
+
+  specify 'it can be removed' do
+    RUMMAGER_INDEX.stub(:delete) { true }
+
+    delete_contact(contact)
+
+    verify !contact_exists(contact)
+  end
+end

--- a/spec/features/steps/admin/contact_steps.rb
+++ b/spec/features/steps/admin/contact_steps.rb
@@ -12,11 +12,8 @@ module Admin
     end
 
     def delete_contact(contact)
-      ensure_on admin_contacts_path
-
-      within(contacts_table_selector) do
-        click_link 'Remove'
-      end
+      ensure_on edit_admin_contact_path(contact)
+      click_link 'Delete'
     end
 
     def update_contact(contact, new_details = {})

--- a/spec/interactors/admin/destroy_contact_spec.rb
+++ b/spec/interactors/admin/destroy_contact_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Admin::DestroyContact do
+  describe '#destroy' do
+    context 'rummager throws an error' do
+      let(:contact) { create :contact }
+
+      it 'does not destroy the contact' do
+        described_class.new(contact).destroy
+
+        expect(contact.reload).to be_present
+      end
+    end
+
+    context 'rummager does not throw an error' do
+      let(:contact) { create :contact }
+
+      it 'destroys the contact' do
+        RUMMAGER_INDEX.stub(:delete) { true }
+
+        described_class.new(contact).destroy
+
+        expect { contact.reload }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to clean up contacts from rummager once they are deleted and not delete the contact if rummager is down.

Also we periodically reindex all contacts, could use another interactor but this will do for now.
