### PR TITLE
Use papertrail for an audit log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'slimmer', '~> 3.20.0'
 gem 'stringex', '2.1.0'
 gem 'unicorn', '~> 4.6.3'
 gem 'virtus', '~> 1.0.0.beta8'
+gem 'paper_trail', '>= 3.0.0.beta1'
 
 gem 'gds-sso', github: 'alphagov/gds-sso', branch: 'master', ref: 'bf4b6d13a1'
 gem 'gds-api-adapters', '~> 7.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
+    paper_trail (3.0.0.beta1)
+      activerecord (>= 3.0, < 5.0)
     plek (1.4.0)
     polyglot (0.3.3)
     pry (0.9.12.2)
@@ -313,6 +315,7 @@ DEPENDENCIES
   jquery-rails
   lrucache (= 0.1.4)
   mysql2 (~> 0.3.13)
+  paper_trail (>= 3.0.0.beta1)
   plek (>= 1.0.0)
   pry-rails
   rack-mini-profiler (~> 0.1.31)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,4 +4,8 @@ class AdminController < ApplicationController
   prepend_before_filter :authenticate_user!
   before_filter :require_signin_permission!
   before_filter :skip_slimmer
+
+  def info_for_paper_trail
+    { user_name: current_user.name }
+  end
 end

--- a/app/models/concerns/versioning.rb
+++ b/app/models/concerns/versioning.rb
@@ -1,0 +1,10 @@
+module Versioning
+  extend ActiveSupport::Concern
+  included do
+    has_paper_trail ignore: [:updated_at, :created_at]
+  end
+
+  def display_versions
+    versions.order(created_at: :desc)
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,6 @@
 class Contact < ActiveRecord::Base
+  include Versioning
+
   acts_as_url :title, url_attribute: :slug, sync_url: true
 
   belongs_to :department

--- a/app/models/contact_group.rb
+++ b/app/models/contact_group.rb
@@ -1,5 +1,6 @@
 class ContactGroup < ActiveRecord::Base
   extend ActiveHash::Associations::ActiveRecordExtensions
+  include Versioning
 
   acts_as_url :title, url_attribute: :slug, sync_url: true
 

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,4 +1,6 @@
 class EmailAddress < ActiveRecord::Base
+  include Versioning
+
   belongs_to :contact, inverse_of: :email_addresses, counter_cache: true
 
   validates :contact, presence: true

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,4 +1,6 @@
 class PhoneNumber < ActiveRecord::Base
+  include Versioning
+
   belongs_to :contact, inverse_of: :phone_numbers, counter_cache: true
 
   validates :contact, presence: true

--- a/app/models/post_address.rb
+++ b/app/models/post_address.rb
@@ -1,4 +1,6 @@
 class PostAddress < ActiveRecord::Base
+  include Versioning
+
   belongs_to :contact, inverse_of: :post_addresses, counter_cache: true
 
   validates :contact, presence: true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,6 @@
 class Question < ActiveRecord::Base
+  include Versioning
+
   belongs_to :contact, inverse_of: :questions
 
   validates :title, presence: true

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,4 +1,6 @@
 class Website < ActiveRecord::Base
+  include Versioning
+
   validates :title, presence: true
   validates :link, presence: true
 end

--- a/app/views/admin/contact_groups/edit.html.erb
+++ b/app/views/admin/contact_groups/edit.html.erb
@@ -12,3 +12,16 @@
     <%= render partial: 'form', locals: { contact_group: contact_group } %>
   </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: contact_group.display_versions, as: :version %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/contacts/contact_form_links/edit.html.erb
+++ b/app/views/admin/contacts/contact_form_links/edit.html.erb
@@ -3,7 +3,7 @@
     <div class='page-header'>
       <h2>
         Edit Contact Form Link for <%= contact %>
-        
+
         <%= link_to 'Delete', admin_contact_contact_form_link_path(contact, contact_form_link), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-small text-red pull-right' %>
       </h2>
 
@@ -11,5 +11,18 @@
     </div>
 
     <%= render partial: 'form', locals: { contact: contact, contact_form_link: contact_form_link } %>
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: contact_form_link.display_versions, as: :version %>
+    </table>
   </div>
 </div>

--- a/app/views/admin/contacts/edit.html.erb
+++ b/app/views/admin/contacts/edit.html.erb
@@ -11,5 +11,19 @@
     </div>
 
     <%= render partial: 'form', locals: { contact: contact } %>
+
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: contact.display_versions, as: :version %>
+    </table>
   </div>
 </div>

--- a/app/views/admin/contacts/email_addresses/edit.html.erb
+++ b/app/views/admin/contacts/email_addresses/edit.html.erb
@@ -12,3 +12,16 @@
     <%= render partial: 'form', locals: { contact: contact, email_address: email_address } %>
   </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: email_address.display_versions, as: :version %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/contacts/phone_numbers/edit.html.erb
+++ b/app/views/admin/contacts/phone_numbers/edit.html.erb
@@ -12,3 +12,16 @@
     <%= render partial: 'form', locals: { contact: contact, phone_number: phone_number } %>
   </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: phone_number.display_versions, as: :version %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/contacts/post_addresses/edit.html.erb
+++ b/app/views/admin/contacts/post_addresses/edit.html.erb
@@ -12,3 +12,16 @@
     <%= render partial: 'form', locals: { contact: contact, post_address: post_address } %>
   </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: post_address.display_versions, as: :version %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -10,3 +10,16 @@
     <%= render partial: 'form', locals: { question: question } %>
   </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>Audit log</h3>
+    <table class="table table-striped">
+      <tr>
+        <th>User</th>
+        <th>Action</th>
+        <th>Changes</th>
+      </tr>
+      <%= render partial: 'admin/versions/version', collection: question.display_versions, as: :version %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/versions/_version.html.erb
+++ b/app/views/admin/versions/_version.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td><%= version.user_name %></td>
+  <td><%= version.event %></td>
+  <td><%= version.changeset %></td>
+</tr>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,8 @@ Contacts::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  config.after_initialize do
+    PaperTrail.enabled = false
+  end
 end

--- a/db/migrate/20131002152244_create_versions.rb
+++ b/db/migrate/20131002152244_create_versions.rb
@@ -1,0 +1,18 @@
+class CreateVersions < ActiveRecord::Migration
+  def self.up
+    create_table :versions do |t|
+      t.string   :item_type, :null => false
+      t.integer  :item_id,   :null => false
+      t.string   :event,     :null => false
+      t.string   :whodunnit
+      t.text     :object
+      t.datetime :created_at
+    end
+    add_index :versions, [:item_type, :item_id]
+  end
+
+  def self.down
+    remove_index :versions, [:item_type, :item_id]
+    drop_table :versions
+  end
+end

--- a/db/migrate/20131002155025_add_usernameto_versions.rb
+++ b/db/migrate/20131002155025_add_usernameto_versions.rb
@@ -1,0 +1,5 @@
+class AddUsernametoVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :user_name, :string
+  end
+end

--- a/db/migrate/20131002161548_add_object_changes_to_versions.rb
+++ b/db/migrate/20131002161548_add_object_changes_to_versions.rb
@@ -1,0 +1,5 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :object_changes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130917182459) do
+ActiveRecord::Schema.define(version: 20131002161548) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -125,6 +125,19 @@ ActiveRecord::Schema.define(version: 20130917182459) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "versions", force: true do |t|
+    t.string   "item_type",      null: false
+    t.integer  "item_id",        null: false
+    t.string   "event",          null: false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+    t.string   "user_name"
+    t.text     "object_changes"
+  end
+
+  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
   create_table "websites", force: true do |t|
     t.integer  "contact_id"


### PR DESCRIPTION
Closes #45

Skipping this in the tests. Including the username for display purposes as otherwise we need to join the users table and the ids are stored as strings by papertrail. Using a module to mass configure the skipping of updated_at and doing the sorting of the versions.
