### PR TITLE
Only index contacts with user needs in search

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -21,14 +21,17 @@ class Contact < ActiveRecord::Base
   validates :description, presence: true
 
   scope :by_title, -> { order("title ASC") }
-  scope :ungrouped, -> {
-    where(contact_group_id: nil)
-  }
+  scope :ungrouped, -> { where(contact_group_id: nil) }
+  scope :with_needs, -> { where.not(need_id: nil) }
   scope :for_listing, -> {
     where(
       "`contacts`.`phone_numbers_count` > 0 OR `contacts`.`post_addresses_count` > 0 OR `contacts`.`email_addresses_count` > 0 OR `contacts`.`contact_form_links_count` > 0"
     ).order("contacts.title ASC")
   }
+
+  def self.index_for_seach
+    Contact.includes(:contact_group, :questions, :department).with_needs.map(&:to_indexed_json)
+  end
 
   def to_s
     title

--- a/db/migrate/20140212113736_add_user_need_id_to_contacts.rb
+++ b/db/migrate/20140212113736_add_user_need_id_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddUserNeedIdToContacts < ActiveRecord::Migration
+  def change
+    add_column :contacts, :need_id, :integer
+    add_index :contacts, :need_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140204220206) do
+ActiveRecord::Schema.define(version: 20140212113736) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -69,9 +69,11 @@ ActiveRecord::Schema.define(version: 20140204220206) do
     t.string   "quick_link_title_2"
     t.string   "quick_link_3"
     t.string   "quick_link_title_3"
+    t.integer  "need_id"
   end
 
   add_index "contacts", ["department_id"], name: "index_contacts_on_department_id", using: :btree
+  add_index "contacts", ["need_id"], name: "index_contacts_on_need_id", using: :btree
   add_index "contacts", ["slug"], name: "index_contacts_on_slug", using: :btree
 
   create_table "email_addresses", force: true do |t|

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -8,7 +8,7 @@ namespace :contacts do
 
   desc "Index Contacts & Questions in rummager"
   task index: :environment do
-    RUMMAGER_INDEX.add_batch Contact.includes(:contact_group, :questions, :department).all.map(&:to_indexed_json)
+    RUMMAGER_INDEX.add_batch Contact.index_for_search
     RUMMAGER_INDEX.commit
   end
 


### PR DESCRIPTION
Scope the contacts to be indexed where there is a user need id
No admin interface for this at present, the contacts with needs would
be added via a db migration for now.
