### PR TITLE
Fix for Contacts not being indexed by rummager

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -29,8 +29,8 @@ class Contact < ActiveRecord::Base
     ).order("contacts.title ASC")
   }
 
-  def self.index_for_seach
-    Contact.includes(:contact_group, :questions, :department).with_needs.map(&:to_indexed_json)
+  def self.index_for_search
+    Contact.includes(:contact_groups, :questions).map(&:to_indexed_json)
   end
 
   def to_s
@@ -47,7 +47,8 @@ class Contact < ActiveRecord::Base
       description: description,
       link: link,
       format: "contact",
-      indexable_content: "#{title} #{description} #{questions.map(&:title).join}"
+      indexable_content: "#{title} #{description} #{questions.map(&:title).join}",
+      department: department.as_json
     }
   end
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -74,6 +74,17 @@ class Department
     find_by(attributes) or raise ActiveRecord::RecordNotFound
   end
 
+  def as_json(options={})
+    {
+      id: id,
+      title: title,
+      format: format,
+      slug: slug,
+      abbreviation: abbreviation,
+      govuk_status: govuk_status
+    }
+  end
+
   private
 
   def self.load_departments

--- a/app/tasks/import_contacts/contact_builder.rb
+++ b/app/tasks/import_contacts/contact_builder.rb
@@ -17,7 +17,7 @@ class ImportContacts
       {
         description: attributes["description"],
         contact_group_ids: [ContactGroup.find_by(title: attributes["clustergroup"]).try(:id)],
-        department: attributes.fetch(:department) { Department.find_by abbreviation: "hmrc" }
+        department: attributes.fetch(:department) { Department.find_by slug: "hm-revenue-customs" }
       }
     end
 

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -8,7 +8,9 @@ namespace :contacts do
 
   desc "Index Contacts & Questions in rummager"
   task index: :environment do
-    RUMMAGER_INDEX.add_batch Contact.index_for_search
+    index = Contact.index_for_search
+    puts index.inspect
+    RUMMAGER_INDEX.add_batch index
     RUMMAGER_INDEX.commit
   end
 


### PR DESCRIPTION
Issues in both `contact_builder.rb` and `models/contact.rb` stopped the Contacts from being viewable by rummager, which is used by the `contact#index` page to display the Contacts. I also removed a scope of with_need applied on the method used for the Index because it never returned any records. 
