### PR TITLE
Fix for URL formatting from MarkdownRenderer

### DIFF
--- a/app/tasks/import_contacts/more_info_url.rb
+++ b/app/tasks/import_contacts/more_info_url.rb
@@ -3,7 +3,7 @@ class ImportContacts
     include Virtus.value_object
 
     class MarkdownRenderer
-      URL_PART         = %Q{[%{url}](%{url_title})}
+      URL_PART         = %Q{[%{url_title}](%{url})}
       DESCRIPTION_PART = %Q{%{url_description}}
 
       delegate :url, :description, :title, to: :@more_info_url


### PR DESCRIPTION
From https://www.pivotaltracker.com/story/show/66658408. URL title and URL were the wrong way round on import.
