### PR TITLE
Show "When can I expect a response" if needed

### DIFF
--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -8,6 +8,7 @@
       <%= f.input :description, as: :text, input_html: { rows: 8, class: 'span9' }, hint: formatting_help_link %>
       <%= f.input :before_you_contact_us, as: :text, label: 'Before you contact us', input_html: { rows: 5, class: 'span9' }, hint: formatting_help_link %>
       <%= f.input :contact_information, as: :text, label: 'Information you will need', input_html: { rows: 5, class: 'span9' }, hint: formatting_help_link %>
+      <%= f.input :query_response_time, label: 'Show "When can I expect my reply" link' %>
     </fieldset>
 
     <fieldset class="form-horizontal">

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -9,13 +9,15 @@
 </header>
 
 
-<div class="related block-1 block-pull-right">
-  <div class="inner-block">
-    <h3>
-      <%= link_to "When can I expect a response to my query?", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %>
-    </h3>
+<% if contact.query_response_time? %>
+  <div class="related block-1 block-pull-right">
+    <div class="inner-block">
+      <h3>
+        <%= link_to "When can I expect a response to my query?", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %>
+      </h3>
+    </div>
   </div>
-</div>
+<% end -%>
 
 <%= render "contact_top_details" %>
 

--- a/db/migrate/20140306131958_add_query_response_time_attribute_to_contacts.rb
+++ b/db/migrate/20140306131958_add_query_response_time_attribute_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddQueryResponseTimeAttributeToContacts < ActiveRecord::Migration
+  def change
+    add_column :contacts, :query_response_time, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140305140728) do
+ActiveRecord::Schema.define(version: 20140306131958) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20140305140728) do
     t.string   "quick_link_3"
     t.string   "quick_link_title_3"
     t.integer  "need_id"
+    t.boolean  "query_response_time",            default: false
   end
 
   add_index "contacts", ["department_id"], name: "index_contacts_on_department_id", using: :btree


### PR DESCRIPTION
Adding a boolean attribute on contacts to only show the "When can I expect a response?" link when required.
