### PR TITLE
Breadcrumb links for org, contact org + contact

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -27,11 +27,20 @@ class Department
       title
     end
   end
+
+  def abbreviation_or_title
+    abbreviation || title
+  end
+  
   alias_method :to_s,      :title_with_abbreviation
   alias_method :logo_name, :title_with_abbreviation
 
   def to_param
     slug
+  end
+
+  def url
+    "http://www.gov.uk/government/organisations/#{slug}"
   end
 
   def exempt?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,18 @@
 <% unless local_assigns[:show_breadcrumbs] %>
 <div id="global-breadcrumb" class="header-context group">
   <ol role="breadcrumbs" class="group">
+    <li>
+      <%= link_to "Home", '/' %>
+    </li>
+    <li>
+      <%= link_to department.title, department.url %>
+    </li>
+    <li>
+      <%= link_to "Contact #{department.abbreviation_or_title}", root_path %>
+    </li>
     <% if params[:action] == "show" %>
       <li>
-        <%= link_to "Home", root_path %>
+        <%= link_to contact.title, contact_path(contact.department, contact.slug) %>
       </li>
     <% end %>
   </ol>


### PR DESCRIPTION
After discussion about https://www.pivotaltracker.com/story/show/65740136, we decided that breadcrumb links should be on the pages. Structure and content agreed with Will.
