### PR TITLE
Add popularity to Contact to be used in weighting the listings

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -46,6 +46,7 @@ module Admin
         { contact_group_ids: [] },
         :department_id,
         :description,
+        :popularity,
         :quick_answer,
         :before_you_contact_us,
         :contact_information,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -24,7 +24,7 @@ class Contact < ActiveRecord::Base
   scope :for_listing, -> {
     where(
       "`contacts`.`phone_numbers_count` > 0 OR `contacts`.`post_addresses_count` > 0 OR `contacts`.`email_addresses_count` > 0 OR `contacts`.`contact_form_links_count` > 0"
-    ).order("contacts.title ASC")
+    ).order("contacts.popularity DESC, contacts.title")
   }
 
   def self.index_for_search

--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -9,6 +9,7 @@
       <%= f.input :before_you_contact_us, as: :text, label: 'Before you contact us', input_html: { rows: 5, class: 'span9' }, hint: formatting_help_link %>
       <%= f.input :contact_information, as: :text, label: 'Information you will need', input_html: { rows: 5, class: 'span9' }, hint: formatting_help_link %>
       <%= f.input :query_response_time, as: :boolean, label: 'Show "When can I expect my reply" link' %>
+      <%= f.input :popularity, hint: 'This is used to weight the contacts list, use call volume for example' %>
     </fieldset>
 
     <fieldset class="form-horizontal">

--- a/db/migrate/20140306152429_add_popularity_to_contacts.rb
+++ b/db/migrate/20140306152429_add_popularity_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddPopularityToContacts < ActiveRecord::Migration
+  def change
+    add_column :contacts, :popularity, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140306131958) do
+ActiveRecord::Schema.define(version: 20140306152429) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20140306131958) do
     t.string   "quick_link_title_3"
     t.integer  "need_id"
     t.boolean  "query_response_time",            default: false
+    t.integer  "popularity",                     default: 0
   end
 
   add_index "contacts", ["department_id"], name: "index_contacts_on_department_id", using: :btree


### PR DESCRIPTION
The initial listing page will sort on the popular contacts then by the title
