### PR TITLE
Fix for 500 when using the Topic filter

### DIFF
--- a/app/value_objects/contacts_search.rb
+++ b/app/value_objects/contacts_search.rb
@@ -1,5 +1,5 @@
 class ContactsSearch < Searchlight::Search
-  search_on Contact.includes(:contact_memberships, :contact_groups)
+  search_on Contact.includes(:contact_memberships)
 
   searches :title, :description, :name, :department_id, :contact_group_id
 


### PR DESCRIPTION
If you were to use the Topic filter with a search term, it was 500ing from an ambiguous column name when using `contact_search.rb`. Specifically in the include of `contact_groups`, which wasn't needed for the search to function.

Fix for https://www.pivotaltracker.com/story/show/67092910.
