### PR TITLE
Change of Response text on Contact Show page

### DIFF
--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -51,7 +51,7 @@
   <div class="block-container">
     <div class="block-inner">  
       <p>
-        <%= link_to "Find out", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %> when to expect a response to your query
+        <%= link_to "Find out when to expect a response to your query", "http://www.hmrc.gov.uk/tools/progress-tool/index.htm" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Making the whole sentence a link will make more sense when read by screen readers. Result of accessibility review - https://www.pivotaltracker.com/story/show/67016812
