### PR TITLE
Add constrain for /admin route

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,5 +29,6 @@ Contacts::Application.configure do
 
   config.after_initialize do
     Contacts.worldwide_api = GdsApi::Worldwide.new("https://www.gov.uk")
+    Contacts.enable_admin_routes = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,28 @@
+class AdminRequest
+  def self.matches?(request)
+    Contacts.enable_admin_routes
+  end
+end
+
 Contacts::Application.routes.draw do
   get "healthcheck" => "healthcheck#check"
   scope :path => "#{APP_SLUG}" do
 
-    namespace :admin do
-      root to: 'contacts#index', via: :get
+    constraints(AdminRequest) do
+      namespace :admin do
+        root to: 'contacts#index', via: :get
 
-      resources :contact_groups
-      resources :contacts do
-        member do
-          get :clone
-        end
-        scope module: 'contacts' do
-          resources :contact_form_links
-          resources :email_addresses
-          resources :post_addresses
-          resources :phone_numbers
+        resources :contact_groups
+        resources :contacts do
+          member do
+            get :clone
+          end
+          scope module: 'contacts' do
+            resources :contact_form_links
+            resources :email_addresses
+            resources :post_addresses
+            resources :phone_numbers
+          end
         end
       end
     end

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -4,6 +4,7 @@ module Contacts
   mattr_accessor :contacts_search_client
   mattr_accessor :worldwide_api
   mattr_accessor :organisations_api
+  mattr_accessor :enable_admin_routes
 
   module_function
 end


### PR DESCRIPTION
When trying to hit /admin, the User must be visiting from contacts-admin.preview.alphagov.co.uk or contacts-admin.production.alphagov.co.uk. Relates to https://www.pivotaltracker.com/story/show/67458214
