### PR TITLE
Fix for test env breaking with admin constraints

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,5 +36,6 @@ Contacts::Application.configure do
 
   config.after_initialize do
     PaperTrail.enabled = false
+    Contacts.enable_admin_routes = true
   end
 end


### PR DESCRIPTION
After https://github.com/alphagov/hmrc-contacts/commit/6f162d2301981b4c9268fb48ec5e980c68bc28bc, tests won't work due to enable_admin_routes not being set. This commit fixes that.
