### PR TITLE
Remove exception_notifier.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,6 @@ gem "lrucache", "0.1.4"
 gem "rummageable", github: "alphagov/rummageable", branch: "master"
 gem "plek", ">= 1.0.0"
 
-gem "aws-ses", require: "aws/ses" # Needed by exception_notification
-gem "exception_notification"
 gem "airbrake", "3.1.15"
 
 gem "whenever", "~> 0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,11 +60,6 @@ GEM
     arel (4.0.1)
     ast (1.1.0)
     atomic (1.1.14)
-    aws-ses (0.5.0)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     axiom-types (0.0.5)
       descendants_tracker (~> 0.0.1)
       ice_nine (~> 0.9)
@@ -104,9 +99,6 @@ GEM
     equalizer (0.0.9)
     erubis (2.7.0)
     eventmachine (1.0.3)
-    exception_notification (4.0.1)
-      actionmailer (>= 3.0.4)
-      activesupport (>= 3.0.4)
     execjs (2.0.2)
     factory_girl (4.3.0)
       activesupport (>= 3.0.0)
@@ -308,7 +300,6 @@ GEM
     whenever (0.8.4)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
-    xml-simple (1.1.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -318,7 +309,6 @@ PLATFORMS
 DEPENDENCIES
   active_hash (~> 1.2.0)
   airbrake (= 3.1.15)
-  aws-ses
   bootstrap-sass (= 2.3.2.2)
   capybara
   ci_reporter
@@ -326,7 +316,6 @@ DEPENDENCIES
   decent_decoration (~> 0.0.5)
   decent_exposure (~> 2.3.0)
   draper (~> 1.2.1)
-  exception_notification
   factory_girl_rails
   fakefs
   friendly_id (= 5.0.2)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,6 @@ Contacts::Application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :ses
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).


### PR DESCRIPTION
It's been superceeded by airbrake/errbit

This also removes aws-ses as that was only needed by exception_notification
