### PR TITLE
Only send Slimmer header on show page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  before_filter :set_beta_notice
   after_filter :dev_skip_slimmer
 
   decent_configuration do
@@ -20,7 +19,4 @@ class ApplicationController < ActionController::Base
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
   end
 
-  def set_beta_notice
-    response.header[Slimmer::Headers::BETA_LABEL] = "after:div#contact-details-header"
-  end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,4 +1,7 @@
 class ContactsController < ApplicationController
+
+  before_filter :set_beta_notice, only: :show
+
   expose(:search) {
     ContactsSearch.new search_params
   }
@@ -33,5 +36,9 @@ class ContactsController < ApplicationController
   def search_params
     filter = { department_id: params[:department_id] }
     filter.merge(params.fetch(:search, {}))
+  end
+
+  def set_beta_notice
+    response.header[Slimmer::Headers::BETA_LABEL] = "after:div#contact-details-header"
   end
 end


### PR DESCRIPTION
With the BetaLabel only being shown on the contact show page, the header only needs sent when this page is requested.
