### PR TITLE
Topic dropdown now says All Topics

### DIFF
--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -34,7 +34,7 @@
           <div class="filter">
             <div class="filter-inner">
               <%= label_tag "search[contact_group_id]", "Topic" %>
-              <%= select_tag "search[contact_group_id]", options_for_select(contact_groups.map {|c| [c, c.id]}, search.contact_group_id), { include_blank: "All Topics", class: "single-row-select" } %>
+              <%= select_tag "search[contact_group_id]", options_for_select(contact_groups.map {|c| [c, c.id]}, search.contact_group_id), { prompt: "All Topics", class: "single-row-select" } %>
             </div>
           </div>
 


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/68807936. When we removed the form tag and f.select being a select_tag, it needed passed in using prompt.
