### PR TITLE
Slimmer just includes the header and footer js

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   after_filter :dev_skip_slimmer
+  before_filter :set_slimmer_headers
 
   decent_configuration do
     strategy DecentExposure::StrongParametersStrategy
@@ -18,5 +19,10 @@ class ApplicationController < ActionController::Base
   def skip_slimmer
     response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
   end
+
+   def set_slimmer_headers
+    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
+  end
+
 
 end


### PR DESCRIPTION
While debugging another issue, @edds noticed that there was a lot of JS being included that wasn't needed.
