### PR TITLE
Fix for beta label css missing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "sass-rails", "~> 4.0.0"
 gem "uglifier", ">= 1.3.0"
 gem "coffee-rails", "~> 4.0.0"
 gem "therubyracer", platforms: :ruby
-gem "govuk_frontend_toolkit", "0.34.0"
+gem "govuk_frontend_toolkit", "0.46.1"
 gem "jquery-rails"
 
 gem "select2-rails", github: "argerim/select2-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_frontend_toolkit (0.34.0)
+    govuk_frontend_toolkit (0.46.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashie (2.0.5)
@@ -322,7 +322,7 @@ DEPENDENCIES
   gds-api-adapters (~> 7.20.0)
   gds-sso (~> 9.2.5)
   govspeak (= 1.2.3)
-  govuk_frontend_toolkit (= 0.34.0)
+  govuk_frontend_toolkit (= 0.46.1)
   jquery-rails
   lrucache (= 0.1.4)
   mysql2 (~> 0.3.13)

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -13,6 +13,7 @@
 @import "_shims.scss";
 @import "_css3.scss";
 @import "_device-pixels.scss";
+@import "design-patterns/_alpha-beta.scss";
 
 @import "styleguide/_dimensions.scss";
 @import "styleguide/_font-stacks.scss";

--- a/app/assets/stylesheets/frontend/views/_layouts.scss
+++ b/app/assets/stylesheets/frontend/views/_layouts.scss
@@ -85,3 +85,7 @@ p.report-a-problem-toggle {
     clear: both;
   }
 }
+
+.beta {
+  @include phase-tag(beta);
+}


### PR DESCRIPTION
Version bump of frontend_toolkit and including the alpha-beta file. After https://github.com/alphagov/hmrc-contacts/pull/117, the Beta Label lost it's CSS.
