### PR TITLE
Removing current item in breadcrumb trail

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,12 +24,9 @@
     <li>
       <%= link_to department.title, department.path %>
     </li>
-    <li>
-      <%= link_to "Contact #{department.abbreviation_or_title}", contacts_path(department.slug) %>
-    </li>
     <% if params[:action] == "show" %>
       <li>
-        <%= link_to contact.title, contact_path(contact.department, contact.slug) %>
+        <%= link_to "Contact #{department.abbreviation_or_title}", contacts_path(department.slug) %>
       </li>
     <% end %>
   </ol>


### PR DESCRIPTION
In order to avoid repetition of text, I've removed the current item from the breadcrumb nav to match the way they are used on the rest of GOV.UK.
