### PR TITLE
Add more spacing around report a problem

### DIFF
--- a/app/assets/stylesheets/frontend/views/_layouts.scss
+++ b/app/assets/stylesheets/frontend/views/_layouts.scss
@@ -59,6 +59,7 @@ p.report-a-problem-toggle {
   clear: both;
   margin: $gutter-half;
   direction: ltr;
+  padding-top: $gutter;
   @include media(tablet){
     margin: $gutter;
   }


### PR DESCRIPTION
A bit more padding around the report a problem toggle to move it away from the list of contacts.

**Form hidden:**

![screen shot 2014-04-29 at 14 13 27](https://cloud.githubusercontent.com/assets/449004/2829210/1d223e78-cfa0-11e3-9b6f-8c3546330504.png)

**Form shown:**

![screen shot 2014-04-29 at 14 13 35](https://cloud.githubusercontent.com/assets/449004/2829209/1d11dde4-cfa0-11e3-83d7-4066c82f25dc.png)
