### PR TITLE
Use Org.id on ContactGroup form for association

### DIFF
--- a/app/views/admin/contact_groups/_form.html.erb
+++ b/app/views/admin/contact_groups/_form.html.erb
@@ -2,7 +2,7 @@
   <fieldset class="form-horizontal">
     <%= f.input :title, input_html: { class: 'span6' } %>
     <%= f.input :description, as: :text, input_html: { rows: 8, class: 'span6' }, hint: formatting_help_link %>
-    <%= f.input :organisation_id, label: "Organisation", collection: Organisation.all, label_method: :to_s, value_method: :slug, include_blank: false, input_html: { class: 'span3 js-select2' } %>
+    <%= f.input :organisation_id, label: "Organisation", collection: Organisation.all, label_method: :to_s, value_method: :id, include_blank: false, input_html: { class: 'span3 js-select2' } %>
     <%= f.association :contact_group_type, collection: ContactGroupType.all, include_blank: false, input_html: { class: 'span3 js-select2' } %>
   </fieldset>
 


### PR DESCRIPTION
The ContactGroup form was previously using slug to try and make an association, after the change to store Orgs locally, this was failing.
