### PR TITLE
Update route registration to reflect new vhost

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -7,11 +7,11 @@ namespace :router do
   end
 
   task :register_backend => :router_environment do
-    @router_api.add_backend('contacts-frontend', Plek.current.find('contacts-frontend', :force_http => true) + "/")
+    @router_api.add_backend('contacts-frontend-old', Plek.current.find('contacts-frontend-old', :force_http => true) + "/")
   end
 
   task :register_routes => :router_environment do
-    @router_api.add_route('/contact/hm-revenue-customs', 'prefix', 'contacts-frontend')
+    @router_api.add_route('/contact/hm-revenue-customs', 'prefix', 'contacts-frontend-old')
   end
 
   desc "Register Contacts application and routes with the router"


### PR DESCRIPTION
The frontend part of the app is currently listening on 2 vhosts -
contacts-frontend and contacts-frontend-old.  Before long the former
will be reclaimed for the new frontend app, so the routes need to be
pointed at the latter.
