### PR TITLE
Fix a typo that causes a server error when searching

### DIFF
--- a/app/views/contacts/index.js.erb
+++ b/app/views/contacts/index.js.erb
@@ -1,3 +1,3 @@
 $("#working_on_filter_contacts").addClass("hidden");
 $(".document-list").html("<%= j render @contacts %>");
-$(".contacts-count").removeClass("hidden").html("<%= j render 'contacts_count', contacts: @contact %>");
+$(".contacts-count").removeClass("hidden").html("<%= j render 'contacts_count', contacts: @contacts %>");


### PR DESCRIPTION
The wrong variable name is being assigned to the partial local variables and is causing a error when searching.
