### PR TITLE
Remove unicorn config.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,0 @@
-govuk_defaults = '/etc/govuk/unicorn.rb'
-instance_eval(File.read(govuk_defaults), govuk_defaults) if File.exist?(govuk_defaults)
-
-worker_processes 4


### PR DESCRIPTION
The only thing it changed was the worker count, which was upped from the default of 2 to 4.  This app does not need 4 workers per box.

This was probably just copied from Whitehall as opposed to set intentionally.
