### PR TITLE
Configure asset host in development mode.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,9 @@ Contacts::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.assets.prefix = "/assets"
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 
   config.after_initialize do
     Contacts.enable_admin_routes = true


### PR DESCRIPTION
When run under `govuk_setenv`, this configures the asset_host to point
at the assets-origin on the dev VM.  This will give us better dev-prod
parity, and enable running this behind the router in dev.

This also removes the override of the assets prefix in development.
There shouldn't be a need to override this.
