### PR TITLE
Remove hokey JS on update action

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -12,10 +12,7 @@ class Admin::ContactsController < AdminController
 
   def update
     if @contact.update_attributes(contact_params)
-      respond_to do |format|
-        format.html { redirect_to edit_admin_contact_path(@contact), notice: "Contact successfully updated" }
-        format.js { render :edit }
-      end
+      redirect_to successful_update_url, notice: "Contact successfully updated"
     else
       render :edit
     end
@@ -46,6 +43,14 @@ class Admin::ContactsController < AdminController
   end
 
   private
+
+  def successful_update_url
+    if params[:tab].present?
+      [:admin, @contact, params[:tab]]
+    else
+      [:edit, :admin, @contact]
+    end
+  end
 
   def load_contact
     @contact = Contact.find(params[:id])

--- a/app/views/admin/contacts/_span.js.erb
+++ b/app/views/admin/contacts/_span.js.erb
@@ -1,5 +1,0 @@
-<% if contact.valid? %>
-{ class: "alert alert-success", text: "Updated" }
-<% else %>
-{ class: "alert alert-error", text: "<%= contact.errors.full_messages.join(', ') %>"}
-<% end %>

--- a/app/views/admin/contacts/contact_form_links/_more_info_form.html.erb
+++ b/app/views/admin/contacts/contact_form_links/_more_info_form.html.erb
@@ -1,6 +1,7 @@
-<%= render partial: 'admin/shared/formatting' %>
+<%= render 'admin/shared/formatting' %>
 
-<%= simple_form_for [:admin, contact], remote: true do |f| %>
+<%= simple_form_for [:admin, contact] do |f| %>
+  <%= hidden_field_tag :tab, 'contact_form_links' %>
   <fieldset class="form-horizontal">
     <legend>Extra information for Online Links</legend>
     <%= f.input :more_info_contact_form,
@@ -8,6 +9,6 @@
                 placeholder: "This appears below Contact Form method",
                 input_html: { rows: 5, class: "span9" },
                 hint: formatting_help_link %>
-    <%= f.submit "Update", class: 'btn btn-primary', data: { disable_with: "Working" } %>
+    <%= f.submit "Update", class: "btn btn-primary" %>
   </fieldset>
 <% end %>

--- a/app/views/admin/contacts/edit.js.erb
+++ b/app/views/admin/contacts/edit.js.erb
@@ -1,9 +1,0 @@
-(function () {
-  var $span = $("<span />", <%= render "span" %>);
-  $("form.edit_contact fieldset").append($span.hide().fadeIn());
-  setTimeout(function (){
-    $span.fadeOut(function (){
-      $span.remove()
-    });
-  }, 5000);
-})();

--- a/app/views/admin/contacts/email_addresses/_more_info_form.html.erb
+++ b/app/views/admin/contacts/email_addresses/_more_info_form.html.erb
@@ -1,6 +1,7 @@
 <%= render 'admin/shared/formatting' %>
 
-<%= simple_form_for [:admin, contact], remote: true do |f| %>
+<%= simple_form_for [:admin, contact] do |f| %>
+  <%= hidden_field_tag :tab, 'email_addresses' %>
   <fieldset class="form-horizontal">
     <legend>Extra information for Email Address method</legend>
     <%= f.input :more_info_email_address,
@@ -8,6 +9,6 @@
                 placeholder: "This appears below email method",
                 input_html: { rows: 5, class: "span9" },
                 hint: formatting_help_link %>
-    <%= f.submit "Update", class: "btn btn-primary", data: { disable_with: "Working" } %>
+    <%= f.submit "Update", class: "btn btn-primary" %>
   </fieldset>
 <% end %>

--- a/app/views/admin/contacts/phone_numbers/_more_info_form.html.erb
+++ b/app/views/admin/contacts/phone_numbers/_more_info_form.html.erb
@@ -1,6 +1,7 @@
 <%= render 'admin/shared/formatting' %>
 
-<%= simple_form_for [:admin, contact], remote: true do |f| %>
+<%= simple_form_for [:admin, contact] do |f| %>
+  <%= hidden_field_tag :tab, 'phone_numbers' %>
   <fieldset class="form-horizontal">
     <legend>Extra information for Phone Number method</legend>
     <%= f.input :more_info_phone_number,
@@ -8,6 +9,6 @@
                 placeholder: "This appears below phone method",
                 input_html: { rows: 5, class: "span9" },
                 hint: formatting_help_link %>
-    <%= f.submit "Update", class: "btn btn-primary", data: { disable_with: "Working" } %>
+    <%= f.submit "Update", class: "btn btn-primary" %>
   </fieldset>
 <% end %>

--- a/app/views/admin/contacts/post_addresses/_more_info_form.html.erb
+++ b/app/views/admin/contacts/post_addresses/_more_info_form.html.erb
@@ -1,6 +1,7 @@
 <%= render 'admin/shared/formatting' %>
 
-<%= simple_form_for [:admin, contact], remote: true do |f| %>
+<%= simple_form_for [:admin, contact] do |f| %>
+  <%= hidden_field_tag :tab, 'post_addresses' %>
   <fieldset class="form-horizontal">
     <legend>Extra information for Postal Address method</legend>
     <%= f.input :more_info_post_address,
@@ -8,6 +9,6 @@
                 placeholder: "This appears below postal method",
                 input_html: { rows: 5, class: "span9" },
                 hint: formatting_help_link  %>
-    <%= f.submit "Update", class: "btn btn-primary", data: { disable_with: "Working" } %>
+    <%= f.submit "Update", class: "btn btn-primary" %>
   </fieldset>
 <% end %>

--- a/spec/features/admin/contact_edit_spec.rb
+++ b/spec/features/admin/contact_edit_spec.rb
@@ -6,8 +6,6 @@ describe "Contact editing", auth: :user do
   let!(:contact_group) { create(:contact_group, title: "new contact type") }
   let!(:contact)       { create :contact }
 
-  before { Contact.count.should eq(1) }
-
   specify "it can be updated" do
     update_contact(
       contact,
@@ -38,5 +36,24 @@ describe "Contact editing", auth: :user do
                   )
 
     assert_content_store_put_item(contact.link, title: "new title", description: "new description")
+  end
+
+  specify "updating more info fields from tabs redirects the user back to the tab" do
+    can_update_more_info_from_tab(contact, 'email_addresses', 'more_info_email_address')
+    can_update_more_info_from_tab(contact, 'post_addresses', 'more_info_post_address')
+    can_update_more_info_from_tab(contact, 'phone_numbers', 'more_info_phone_number')
+    can_update_more_info_from_tab(contact, 'contact_form_links', 'more_info_contact_form')
+  end
+
+private
+
+  def can_update_more_info_from_tab(contact, tab, attribute_name)
+    ensure_on url_for([:admin, contact, tab])
+
+    fill_in "contact_#{attribute_name}", with: "More info details."
+    click_on "Update"
+
+    expect(page.current_url).to eq(url_for([:admin, contact, tab]))
+    expect(page).to have_field("contact_#{attribute_name}", with: "More info details.")
   end
 end


### PR DESCRIPTION
The app was using remote (JS) form-submission to update the "more info" attribute on the main Contact model from the various tabs. The only reason I can think that it was doing this was to keep the user on the current tab (whereas doing a standard Rails non-AJAX update would generally have redirected the user back to the main contact tab). This replaces the remote form submission, using a hidden parameter in the form to identify the tab the user was on and thus where they should be sent after a successful update.

This does mean that the user will be shown the contacts#edit page if there are validation errors, but given that there are no validations on any of the "more info" attributes, this should never happen.

This will resolve an exception that is currently being raised due to the removal of `decent_exposure` gem: https://errbit.production.alphagov.co.uk/apps/5333f0520da1156aab03efc2/problems/53b1718e0da1157ee0001440
