### PR TITLE
Support new contacts URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,4 +26,15 @@ module ApplicationHelper
   def formatting_help_link(show_section = "")
     "<a href='#formatting#{show_section if show_section.present?}' role='button' data-toggle='modal'>formatting help</a>".html_safe
   end
+
+  # This hackery is necessary while we're supporting both the new and the legacy routes.
+  # We want the legacy index page to link to the legacy show URL, while the new index
+  # page should link to the new show URL
+  def calculate_contact_path(org, contact)
+    if request.path == legacy_contacts_path(org)
+      legacy_contact_path(org, contact)
+    else
+      contact_path(org, contact)
+    end
+  end
 end

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,6 +1,6 @@
 <li class="organisation js-filter-item document-row" data-filter-terms="<%= contact %>">
   <h3 id="<%= contact.slug %>">
-    <%= link_to contact, contact_path(organisation, contact) %>
+    <%= link_to contact, calculate_contact_path(organisation, contact) %>
   </h3>
   <p class="contact-meta">
     <%= contact.contact_groups.join(", ") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,11 +26,12 @@ Contacts::Application.routes.draw do
     end
   end
 
+  get "/government/organisations/:organisation_slug/contact" => "contacts#index", :as => :contacts
+  get "/government/organisations/:organisation_slug/contact/:id" => "contacts#show", :as => :contact, :constraints => {:id => SLUG_FORMAT }
 
-  get "/#{APP_SLUG}/:organisation_slug" => "contacts#index", :as => :contacts
-  get "/#{APP_SLUG}/:organisation_slug/:id" => "contacts#show", :as => :contact, :constraints => {:id => SLUG_FORMAT }
+  get "/contact/:organisation_slug" => "contacts#index", :as => :legacy_contacts
+  get "/contact/:organisation_slug/:id" => "contacts#show", :as => :legacy_contact, :constraints => {:id => SLUG_FORMAT }
 
   # DEFAULT TO HMRC
-  get "/#{APP_SLUG}" => redirect("/#{APP_SLUG}/hm-revenue-customs", status: 302)
-  root :to => redirect("/#{APP_SLUG}/hm-revenue-customs", status: 302)
+  root :to => redirect("/government/organisations/hm-revenue-customs/contact", status: 302)
 end

--- a/spec/features/public/contacts_index_spec.rb
+++ b/spec/features/public/contacts_index_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "Contacts index page" do
+  let!(:hmrc)          { create :organisation, :title => "HM Revenue & Customs" }
+  let!(:contact)       { create(:contact, :with_phone_numbers, :with_contact_group, organisation: hmrc) }
+  let!(:contact2)      { create(:contact, :with_phone_numbers, :with_contact_group, organisation: hmrc) }
+  let!(:other_contact) { create(:contact, :with_phone_numbers, :with_contact_group) }
+
+
+  it "should render the index page with contacts" do
+    visit "/government/organisations/#{hmrc.slug}/contact"
+
+    expect(page).to have_content("HM Revenue & Customs")
+
+    expect(page).to have_link(contact.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact.slug}")
+    expect(page).to have_link(contact2.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact2.slug}")
+  end
+
+  it "should render the index page at the old URL with the old contact page links" do
+    visit "/contact/#{hmrc.slug}"
+
+    expect(page).to have_content("HM Revenue & Customs")
+
+    expect(page).to have_link(contact.title, :href => "/contact/#{hmrc.slug}/#{contact.slug}")
+    expect(page).to have_link(contact2.title, :href => "/contact/#{hmrc.slug}/#{contact2.slug}")
+  end
+end


### PR DESCRIPTION
Contact pages are going to be served from `/government/organisations/<org_slug>/contact` instead of the original url of `/contact/<org_slug>`. This change makes this app support both schemes. The old one will be removed once everything has switched over.
