### PR TITLE
Remove contents of config/schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,9 +1,1 @@
-# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
-env :PATH, '/usr/local/bin:/usr/bin:/bin'
-
-# We need Rake to use our own environment
-job_type :rake, "cd :path && govuk_setenv contacts bundle exec rake :task --silent :output"
-
-every :hour do
-  rake "contacts:index"
-end
+# This file is written on deploy


### PR DESCRIPTION
This is overwritten on deploy, (and with different jobs), so having this
present is just misleading.
