### PR TITLE
Don't include rendering_app with individual routes.

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -18,7 +18,7 @@ class ContactPresenter
       update_type: "major",
       public_updated_at: contact.updated_at,
       routes: [
-        { path: contact.link, type: "exact", rendering_app: "contacts-frontend" }
+        { path: contact.link, type: "exact" }
       ],
       details: contact_details.merge(language: "en"),
       need_ids: [],


### PR DESCRIPTION
This only needs to be set on the item, not on the individual routes (see
https://github.com/alphagov/content-store/blob/master/doc/input_examples/generic.json).
This value was being ignored, but it's best to remove it to avoid any
confusion.
