### PR TITLE
Fix router registration.

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -11,7 +11,7 @@ namespace :router do
   end
 
   task :register_routes => :router_environment do
-    @router_api.add_route('/government/organisations/hm-revenue-customs/contact', 'prefix', 'contacts-frontend-old')
+    @router_api.add_route('/government/organisations/hm-revenue-customs/contact', 'prefix', 'contacts-frontend-old', :commit => true)
   end
 
   desc "Register Contacts application and routes with the router"


### PR DESCRIPTION
gds-api-adapters was bumped to 11.x in 8d59353f which changed the API
for the router client.  It no longer commits automatically.
