### PR TITLE
Register an exact route for the index.

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -11,7 +11,7 @@ namespace :router do
   end
 
   task :register_routes => :router_environment do
-    @router_api.add_route('/government/organisations/hm-revenue-customs/contact', 'prefix', 'contacts-frontend-old', :commit => true)
+    @router_api.add_route('/government/organisations/hm-revenue-customs/contact', 'exact', 'contacts-frontend-old', :commit => true)
   end
 
   desc "Register Contacts application and routes with the router"


### PR DESCRIPTION
Now that the leaf pages are being served by the contacts-frontend app,
we don't need a prefix route here.  Converting this to an exact route
will prevent some of the errors we've been seeing with people trying
alternitave formats etc.

Note: I'll clean up the existing prefix route manually.
