### PR TITLE
Publish to the publishing API vhost.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "virtus", "~> 1.0.0.beta8"
 gem "paper_trail", ">= 3.0.0.beta1"
 gem "govspeak", "1.2.3"
 gem "gds-sso", "~> 9.3.0"
-gem "gds-api-adapters", "~> 11.2.0"
+gem "gds-api-adapters", '~> 14.0'
 gem "lrucache", "0.1.4"
 gem "rummageable", github: "alphagov/rummageable", branch: "master"
 gem "plek", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,11 +114,12 @@ GEM
       multipart-post (>= 1.2, < 3)
     friendly_id (5.0.2)
       activerecord (~> 4.0.0)
-    gds-api-adapters (11.2.0)
+    gds-api-adapters (14.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rack-cache
       rest-client (~> 1.6.3)
     gds-sso (9.3.0)
       multi_json (~> 1.0)
@@ -199,6 +200,8 @@ GEM
       pry (>= 0.9.10)
     rack (1.5.2)
     rack-accept (0.4.5)
+      rack (>= 0.4)
+    rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -334,7 +337,7 @@ DEPENDENCIES
   factory_girl_rails
   fakefs
   friendly_id (= 5.0.2)
-  gds-api-adapters (~> 11.2.0)
+  gds-api-adapters (~> 14.0)
   gds-sso (~> 9.3.0)
   govspeak (= 1.2.3)
   govuk_frontend_toolkit (= 0.46.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require 'rails/all'
 require 'gds_api/worldwide'
 require 'gds_api/organisations'
 require 'gds_api/rummager'
-require 'gds_api/content_store'
+require 'gds_api/publishing_api'
 require 'rummageable'
 
 # Require the gems listed in Gemfile, including any gems
@@ -49,7 +49,7 @@ module Contacts
       # Going to use the same index as mainstream till rummager has multi index search
       Contacts.rummager_client = Rummageable::Index.new( Plek.current.find('search'), 'mainstream', logger: Rails.logger )
 
-      Contacts.content_store_api = GdsApi::ContentStore.new(Plek.current.find('content-store'))
+      Contacts.publishing_api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))
     end
   end
 end

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -5,7 +5,7 @@ module Contacts
   mattr_accessor :worldwide_api
   mattr_accessor :organisations_api
   mattr_accessor :enable_admin_routes
-  mattr_accessor :content_store_api
+  mattr_accessor :publishing_api
 
   module_function
 end

--- a/lib/contacts/register_contact.rb
+++ b/lib/contacts/register_contact.rb
@@ -2,7 +2,7 @@ module Contacts
   class RegisterContact
     def self.register(presenter)
       presented = presenter.present
-      Contacts.content_store_api.put_content_item(presented[:base_path], presented)
+      Contacts.publishing_api.put_content_item(presented[:base_path], presented)
     end
   end
 end

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -37,7 +37,7 @@ namespace :contacts do
     end
   end
 
-  desc "Register all contacts with the content-store"
+  desc "Register all contacts with the publishing-api"
   task :register_in_content_store => :environment do
     Contact.find_each do |contact|
       p = ContactPresenter.new(contact)

--- a/spec/features/admin/contact_edit_spec.rb
+++ b/spec/features/admin/contact_edit_spec.rb
@@ -29,13 +29,13 @@ describe "Contact editing", auth: :user do
     verify associated_to_contact_group(contact, contact_group)
   end
 
-  specify "updating a contact sends the data to the content-store" do
+  specify "updating a contact sends the data to the publishing-api" do
     update_contact(contact,
                    title: "new title",
                    description: "new description"
                   )
 
-    assert_content_store_put_item(contact.link, title: "new title", description: "new description")
+    assert_publishing_api_put_item(contact.link, title: "new title", description: "new description")
   end
 
   specify "updating more info fields from tabs redirects the user back to the tab" do

--- a/spec/models/register_contact_spec.rb
+++ b/spec/models/register_contact_spec.rb
@@ -4,9 +4,9 @@ describe Contacts::RegisterContact do
   let!(:presenter) { double("ContactPresenter") }
   let!(:presented_contact) { { base_path: '/base-path', title: 'title' } }
 
-  it "sends data to the content-store on register" do
+  it "sends data to the publishing-api on register" do
     presenter.should_receive(:present).and_return(presented_contact)
-    Contacts.content_store_api.should_receive(:put_content_item).with('/base-path', presented_contact)
+    Contacts.publishing_api.should_receive(:put_content_item).with('/base-path', presented_contact)
 
     Contacts::RegisterContact.register(presenter)
   end

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -1,8 +1,8 @@
-require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/publishing_api'
 
 RSpec.configure do |config|
-  config.include GdsApi::TestHelpers::ContentStore
+  config.include GdsApi::TestHelpers::PublishingApi
   config.before(:each) do
-    stub_default_content_store_put
+    stub_default_publishing_api_put
   end
 end


### PR DESCRIPTION
This uses the latest api adapters which implements a separate publishing
API client for content item writes.  See https://github.com/alphagov/gds-api-adapters/pull/191 for more details.
