### PR TITLE
Migration to convert all tables to utf8.

### DIFF
--- a/db/migrate/20140908143214_convert_tables_to_utf8.rb
+++ b/db/migrate/20140908143214_convert_tables_to_utf8.rb
@@ -1,0 +1,27 @@
+class ConvertTablesToUtf8 < ActiveRecord::Migration
+  def change
+    # When MySQL converts a table to utf8 it also automatically converts all
+    # text columns to mediumtext, because utf8 can use three times more space
+    # per character so text wouldn't be long enough. We don't want that, so
+    # find all text fields for conversion back to text afterwards.
+    connection = ActiveRecord::Base.connection
+    text_cols = {}
+    connection.tables.each do |t|
+      columns = connection.schema_cache.columns[t].select {|c| c.type == :text}
+      text_cols[t] = columns if !columns.empty?
+    end
+
+    connection.tables.each do |t|
+      puts "Converting table #{t}"
+      connection.execute("ALTER TABLE #{t} CONVERT TO CHARACTER SET utf8")
+    end
+    text_cols.each do |t, cols|
+      cols.each do |col|
+        c = col.name
+        puts "Modifying column #{c} for table #{t}"
+        connection.execute("ALTER TABLE #{t} MODIFY COLUMN #{c} text")
+      end
+    end
+    connection.execute("ALTER DATABASE #{connection.current_database} DEFAULT CHARACTER SET utf8")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140529140836) do
+ActiveRecord::Schema.define(version: 20140908143214) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"


### PR DESCRIPTION
This migration converts the tables directly via ALTER TABLE statements. This should be safe, because there is little content in the database and HMRC have so far been unable to enter characters outside the usual ASCII range, which is precisely what this change is intended to fix.
