### PR TITLE
Register contact on save of associated items

### DIFF
--- a/app/models/concerns/register_parent.rb
+++ b/app/models/concerns/register_parent.rb
@@ -1,0 +1,11 @@
+module RegisterParent
+  extend ActiveSupport::Concern
+  included do
+    after_save :register_parent
+  end
+
+  def register_parent
+    presenter = ContactPresenter.new(self.contact)
+    Contacts::RegisterContact.register(presenter)
+  end
+end

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,5 +1,6 @@
 class EmailAddress < ActiveRecord::Base
   include Versioning
+  include RegisterParent
 
   belongs_to :contact, inverse_of: :email_addresses, counter_cache: true
 

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,5 +1,6 @@
 class PhoneNumber < ActiveRecord::Base
   include Versioning
+  include RegisterParent
 
   belongs_to :contact, inverse_of: :phone_numbers, counter_cache: true
 

--- a/app/models/post_address.rb
+++ b/app/models/post_address.rb
@@ -1,5 +1,6 @@
 class PostAddress < ActiveRecord::Base
   include Versioning
+  include RegisterParent
 
   belongs_to :contact, inverse_of: :post_addresses, counter_cache: true
 

--- a/app/models/website/contact_form_link.rb
+++ b/app/models/website/contact_form_link.rb
@@ -1,4 +1,5 @@
 class ContactFormLink < Website
+  include RegisterParent
   belongs_to :contact, inverse_of: :contact_form_links, counter_cache: true
 
   validates :contact, presence: true

--- a/spec/features/public/view_contact_spec.rb
+++ b/spec/features/public/view_contact_spec.rb
@@ -3,19 +3,11 @@ require 'gds_api/test_helpers/worldwide'
 include GdsApi::TestHelpers::Worldwide
 
 describe "Contact view" do
-  let!(:hmrc)    { create :organisation }
-  let!(:contact) { create :contact, :with_contact_group, :with_contact_form_links, :with_post_addresses, :with_phone_numbers, :with_email_addresses }
+  let(:hmrc)    { create :organisation }
+  let(:contact) { create :contact, :with_contact_group, :with_contact_form_links, :with_post_addresses, :with_phone_numbers, :with_email_addresses }
 
   before {
-    @location_slugs = %w(
-        afghanistan angola aruba bangladesh belarus brazil brunei
-        cambodia chad croatia denmark eritrea france ghana iceland
-        japan laos luxembourg malta micronesia mozambique nicaragua
-        panama portugal sao-tome-and-principe singapore south-korea
-        sri-lanka uk-delegation-to-council-of-europe
-        uk-delegation-to-organization-for-security-and-co-operation-in-europe
-        united-kingdom venezuela vietnam)
-    worldwide_api_has_locations(@location_slugs)
+    worldwide_api_has_selection_of_locations
     contact.organisation = hmrc
     contact.save!
     visit contact_path(contact.organisation.slug, contact)

--- a/spec/interactors/admin/clone_contact_spec.rb
+++ b/spec/interactors/admin/clone_contact_spec.rb
@@ -3,7 +3,10 @@ require "spec_helper"
 describe Admin::CloneContact do
   describe "#clone" do
     context "contact exists" do
-      let!(:contact) { create :contact, :with_contact_group, :with_contact_form_links, :with_post_addresses, :with_phone_numbers, :with_email_addresses }
+      let(:contact) { create :contact, :with_contact_group, :with_contact_form_links, :with_post_addresses, :with_phone_numbers, :with_email_addresses }
+      before {
+        worldwide_api_has_selection_of_locations
+      }
 
       it "clones the contact and returns the clone" do
         clone = described_class.new(contact).clone

--- a/spec/models/contact_form_link_spec.rb
+++ b/spec/models/contact_form_link_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 describe ContactFormLink do
+  let(:item) { create(:contact_form_link) }
+  it_behaves_like "an associated data model"
+
   it { should validate_presence_of :title }
   it { should validate_presence_of :link }
 end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 describe EmailAddress do
+  let(:item) { create(:email_address) }
+  it_behaves_like "an associated data model"
+
   describe "validations" do
     it { should validate_presence_of :contact }
     it { should validate_presence_of :title }

--- a/spec/models/phone_number_spec.rb
+++ b/spec/models/phone_number_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 describe PhoneNumber do
+  let(:item) { create(:phone_number) }
+  it_behaves_like "an associated data model"
+
   it { should validate_presence_of :contact }
   it { should validate_presence_of :title }
   it { should validate_presence_of :number }

--- a/spec/models/post_address_spec.rb
+++ b/spec/models/post_address_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 describe PostAddress do
+  let(:item) { create(:post_address) }
+  it_behaves_like "an associated data model"
+
   it { should validate_presence_of :contact }
   it { should validate_presence_of :title }
   it { should validate_presence_of :street_address }

--- a/spec/support/shared_contexts/associated_data.rb
+++ b/spec/support/shared_contexts/associated_data.rb
@@ -1,0 +1,10 @@
+shared_context "an associated data model" do
+  it "registers its parent contact on save" do
+    presenter = double("ContactPresenter")
+    expect(ContactPresenter).to receive(:new).with(item.contact).and_return(presenter)
+    expect(Contacts::RegisterContact).to receive(:register).with(presenter)
+
+    item.title = "Winter is coming"
+    item.save
+  end
+end


### PR DESCRIPTION
Currently, contacts are registered with content_store on change of the main Contact model only. This change adds hooks on the associated models - phone number, email address, postal address, contact form link - so that they trigger registration of the parent Contact when they are saved.
