### PR TITLE
Send content IDs to the content store

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -10,6 +10,7 @@ class ContactPresenter
   def present
     {
       base_path: contact.link,
+      content_id: contact.content_id,
       title: contact.title,
       description: contact.description,
       format: "contact",

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
   sequence(:govspeak) { |n| "* something about #{n}" }
 
   factory :contact do
+    content_id          { SecureRandom.uuid }
     title               { generate(:contact_title) }
     description         { generate(:contact_description) }
     contact_information { generate(:contact_information) }

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -7,6 +7,7 @@ describe ContactPresenter do
     payload = ContactPresenter.new(contact).present
 
     expect(payload[:base_path]).to eq("/government/organisations/#{contact.organisation.slug}/contact/#{contact.slug}")
+    expect(payload[:content_id]).to eq(contact.content_id)
     expect(payload[:title]).to eq(contact.title)
     expect(payload[:description]).to eq(contact.description)
     expect(payload[:format]).to eq('contact')


### PR DESCRIPTION
Once contacts in the content store all have content IDs, we'll be able to send in a list of related item links and have the content store look up their published URLs.

This shouldn’t be deployed before alphagov/content-store#47, or the content store will reject the unrecognised `content_id` field.
