### PR TITLE
Add rake task for updating the organisation slug

### DIFF
--- a/app/tasks/organisation_slug_updater.rb
+++ b/app/tasks/organisation_slug_updater.rb
@@ -1,0 +1,40 @@
+class OrganisationSlugUpdater
+  def initialize(old_slug, new_slug, logger = nil)
+    @old_slug = old_slug.sub(%r{^/}, '')
+    @new_slug = new_slug.sub(%r{^/}, '')
+    @logger   = logger || Logger.new(nil)
+  end
+
+  def call
+    if organisation
+      if organisation.contacts.any?
+        logger.warn("This organisation has contacts associated with it therefore we cannot change
+the slug. Please perform this change manually, ensuring all contacts are
+updated and reregistered with the content store.")
+        true
+      else
+        update_organisation_slug
+      end
+    else
+      logger.error("No organisation found for slug: #{old_slug}")
+      false
+    end
+  end
+
+private
+  attr_reader(
+    :old_slug,
+    :new_slug,
+    :logger,
+  )
+
+  def organisation
+    @organisation ||= Organisation.where(slug: old_slug).first
+  end
+
+  def update_organisation_slug
+    updated_result = organisation.update_attribute(:slug, new_slug)
+    logger.info("Updated organisation with slug '#{old_slug}' to use slug '#{new_slug}'")
+    updated_result
+  end
+end

--- a/lib/tasks/update_organisation_slug.rake
+++ b/lib/tasks/update_organisation_slug.rake
@@ -1,0 +1,7 @@
+desc "Update an organisation slug"
+task :update_organisation_slug, [:old_slug, :new_slug] => :environment do |_task, args|
+  logger = Logger.new(STDOUT)
+  logger.error("You must specify [old_slug,new_slug]") unless args.old_slug.present? && args.new_slug.present?
+
+  exit(1) unless OrganisationSlugUpdater.new(old_slug, new_slug, logger).call
+end

--- a/spec/tasks/organisation_slug_updater_spec.rb
+++ b/spec/tasks/organisation_slug_updater_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe OrganisationSlugUpdater do
+
+  let(:new_slug) { 'my-new-slug' }
+  let(:old_slug) { 'my-old-slug' }
+  let!(:organisation) { FactoryGirl.create(:organisation, slug: old_slug) }
+
+  it 'returns true if updated' do
+    expect(OrganisationSlugUpdater.new(old_slug, new_slug).call).to be_true
+  end
+
+  it 'updates the organisation slug' do
+    OrganisationSlugUpdater.new(old_slug, new_slug).call
+    expect(organisation.reload.slug).to eq(new_slug)
+  end
+
+  it 'doesnt contain a leading slash in the organisation slug if one is provided' do
+    OrganisationSlugUpdater.new(old_slug, "/new-slug-with-leading-slash").call
+    expect(organisation.reload.slug).to eq("new-slug-with-leading-slash")
+  end
+
+  it 'returns false if not updated' do
+    expect(OrganisationSlugUpdater.new('anything', new_slug).call).to be_false
+  end
+
+  context 'when the organisation has associated contacts' do
+    let(:contacts) { double(:contacts, any?: true) }
+
+    before do
+      allow_any_instance_of(Organisation).to receive(:contacts).and_return(contacts)
+    end
+
+    it 'should not update the organisation' do
+      OrganisationSlugUpdater.new(old_slug, new_slug).call
+      expect(organisation.reload.slug).to eq(old_slug)
+    end
+
+    it 'returns true in order to exit rake with a 0 exit code' do
+      expect(OrganisationSlugUpdater.new(old_slug, new_slug).call).to be_true
+    end
+  end
+end


### PR DESCRIPTION
This rake task allows for slugs to be changed for an organisation. This task will only make changes however to hmrc-contacts and is expected to be run from a higher level fabric task.
