### PR TITLE
Create a Gone item when deleting contacts

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,5 @@
 require "contacts/register_contact"
+require "contacts/deregister_contact"
 
 class Contact < ActiveRecord::Base
   include Versioning
@@ -8,6 +9,7 @@ class Contact < ActiveRecord::Base
   attr_readonly :content_id
 
   after_save :register_contact
+  before_destroy :deregister_contact
 
   friendly_id :title, use: :history
 
@@ -78,5 +80,10 @@ class Contact < ActiveRecord::Base
   def register_contact
     presenter = ContactPresenter.new(self)
     Contacts::RegisterContact.register(presenter)
+  end
+
+  def deregister_contact
+    presenter = ContactGonePresenter.new(self)
+    Contacts::DeregisterContact.deregister(presenter)
   end
 end

--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -1,0 +1,21 @@
+class ContactGonePresenter
+  include GovspeakHelper
+
+  attr_reader :contact
+
+  def initialize(contact)
+    @contact = contact
+  end
+
+  def present
+    {
+      base_path: contact.link,
+      format: "gone",
+      publishing_app: "contacts",
+      update_type: "major",
+      routes: [
+        { path: contact.link, type: "exact" }
+      ],
+    }
+  end
+end

--- a/lib/contacts/deregister_contact.rb
+++ b/lib/contacts/deregister_contact.rb
@@ -1,0 +1,8 @@
+module Contacts
+  class DeregisterContact
+    def self.deregister(presenter)
+      presented = presenter.present
+      Contacts.publishing_api.put_content_item(presented[:base_path], presented)
+    end
+  end
+end

--- a/spec/features/admin/contact_removal_spec.rb
+++ b/spec/features/admin/contact_removal_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe "Contact removal", auth: :user do
   include Admin::ContactSteps
+  include Admin::PublishingApiSteps
 
   let!(:contact) { create :contact }
 
@@ -11,5 +12,7 @@ describe "Contact removal", auth: :user do
     expect {
       delete_contact(contact)
     }.to change { Contact.count }.by(-1)
+
+    it_should_have_archived_the_page(contact)
   end
 end

--- a/spec/features/steps/admin/publishing_api_steps.rb
+++ b/spec/features/steps/admin/publishing_api_steps.rb
@@ -1,0 +1,22 @@
+module Admin
+  module PublishingApiSteps
+    def gone_item_for(contact)
+      {
+        "base_path" => contact.link,
+        "format" => "gone",
+        "publishing_app" => "contacts",
+        "update_type" => "major",
+        "routes" => [
+          {
+            "path" =>  contact.link,
+            "type" =>  "exact"
+          }
+        ]
+      }
+    end
+
+    def it_should_have_archived_the_page(contact)
+      assert_publishing_api_put_item(contact.link, gone_item_for(contact))
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -15,6 +15,16 @@ describe Contact do
     contact.save
   end
 
+  it "should be deregistered after being destroyed" do
+    contact = create(:contact)
+
+    presenter = double("ContactGonePresenter")
+    ContactGonePresenter.should_receive(:new).with(contact).and_return(presenter)
+    Contacts::DeregisterContact.should_receive(:deregister).with(presenter)
+
+    contact.destroy
+  end
+
   context "content ID" do
 
     it "should be set on a new contact" do

--- a/spec/models/deregister_contact_spec.rb
+++ b/spec/models/deregister_contact_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe Contacts::DeregisterContact do
+  let!(:presenter) { double("ContactPresenter") }
+  let!(:presented_contact) { { base_path: '/base-path', format: 'gone' } }
+
+  it "sends data to the publishing-api on register" do
+    presenter.should_receive(:present).and_return(presented_contact)
+    Contacts.publishing_api.should_receive(:put_content_item).with('/base-path', presented_contact)
+
+    Contacts::DeregisterContact.deregister(presenter)
+  end
+end

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe ContactGonePresenter do
+  let(:contact) { create :contact }
+
+  it "transforms a contact to the correct format" do
+    payload = ContactGonePresenter.new(contact).present
+
+    expect(payload[:base_path]).to eq("/government/organisations/#{contact.organisation.slug}/contact/#{contact.slug}")
+    expect(payload[:format]).to eq('gone')
+    expect(payload[:publishing_app]).to eq("contacts")
+    expect(payload[:update_type]).to eq("major")
+    expect(payload[:routes].first[:path]).to eq(payload[:base_path])
+  end
+end


### PR DESCRIPTION
Before this change, when a contact was deleted, it was left in the content
store, and so remained published on GOV.UK. This bug probably appeared when the
contacts app was split into two and moved to use the content store.

This change means that GOV.UK should display a 410 Gone page.

Ideally we would provide an additional facility to redirect deleted contacts to
another contact or another page, but this change seems far better than silently
leaving old content published.
