### PR TITLE
Back out asset host fixes

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Contacts::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # FIXME: Stop setting asset_host when we split the frontend off into a finder
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Contacts::Application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # FIXME: Stop setting asset_host when we split the frontend off into a finder
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
   # Precompile additional assets.


### PR DESCRIPTION
Contrary to my testing precompiling assets in development, Rails does try to get
the asset_host when precompiling on preview. The code depended upon the request
to do the right thing, so the best idea seems to be to revert it and ignore the
issue with respond.js and IE<9 until we split the frontend off into a finder.
