### PR TITLE
Fix removing from site search

### DIFF
--- a/app/interactors/admin/destroy_contact.rb
+++ b/app/interactors/admin/destroy_contact.rb
@@ -6,7 +6,10 @@ module Admin
 
     def destroy
       @contact.transaction do
-        ::Contacts.rummager_client.delete(@contact.slug)
+        # Remove from site search
+        rummager_id = @contact.link.gsub(%r{^/}, '')
+        ::Contacts.rummager_client.delete(rummager_id)
+
         @contact.destroy
       end
       rescue RestClient::RequestFailed, RestClient::RequestTimeout, RestClient::ServerBrokeConnection, SocketError

--- a/spec/features/admin/contact_removal_spec.rb
+++ b/spec/features/admin/contact_removal_spec.rb
@@ -9,6 +9,8 @@ describe "Contact removal", auth: :user do
   before { Contact.count.should eq(1) }
 
   specify "it can be removed" do
+    it_should_remove_the_page_from_search(contact)
+
     expect {
       delete_contact(contact)
     }.to change { Contact.count }.by(-1)

--- a/spec/features/steps/admin/site_search_steps.rb
+++ b/spec/features/steps/admin/site_search_steps.rb
@@ -1,0 +1,8 @@
+module Admin
+  module PublishingApiSteps
+    def it_should_remove_the_page_from_search(contact)
+      rummager_id = contact.link.gsub(%r{^/}, '')
+      FakeRummageableIndex.any_instance.should_receive(:delete).with(rummager_id)
+    end
+  end
+end


### PR DESCRIPTION
The code for deleting items from GOV.UK site search wouldn't have worked because it was using the slug. Rummager needs the path to the item, omitting the leading slash.

This hasn't been an issue for contacts, because they aren't added to the site search index.

Theoretically, it could have deleted mainstream content from search where the slugs collided, but a review of the contacts that have been deleted indicates this hasn't happened.