### PR TITLE
Prevent duplicate organisations being created

### DIFF
--- a/db/migrate/20150112114049_add_unique_constraint_to_organisation_slugs.rb
+++ b/db/migrate/20150112114049_add_unique_constraint_to_organisation_slugs.rb
@@ -1,0 +1,31 @@
+class AddUniqueConstraintToOrganisationSlugs < ActiveRecord::Migration
+  class Contact < ActiveRecord::Base
+  end
+
+  class Organisation < ActiveRecord::Base
+    has_many :contacts
+  end
+
+  def remove_duplicate_slugs
+    seen_slugs = Set.new
+    Organisation.all.each do |organsition|
+      if seen_slugs.include?(organsition.slug)
+        if organsition.contacts.none?
+          organsition.destroy!
+        end
+      else
+        seen_slugs << organsition.slug
+      end
+    end
+  end
+
+  def up
+    remove_duplicate_slugs
+
+    add_index(:organisations, :slug, unique: true)
+  end
+
+  def down
+    remove_index(:organisations, :slug)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 20150112114153) do
   end
 
   add_index "organisations", ["ancestry"], name: "index_organisations_on_ancestry", using: :btree
+  add_index "organisations", ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
 
   create_table "phone_numbers", force: true do |t|
     t.integer  "contact_id"


### PR DESCRIPTION
For the index to be created, the every value in the field has to be unique, so
we need to deduplicate the field first.