### PR TITLE
Fix "old" search links

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -9,7 +9,11 @@ class ContactsController < ApplicationController
 
   def search_params
     filter = { organisation_id: organisation.id }
-    filter.merge(params.fetch(:search, {}))
+    filter = filter.merge(params.fetch(:search, {}))
+    # rewrite requests using older search parameter name
+    filter[:q] = filter['name']
+    filter.delete('name')
+    filter
   end
 
   def organisation

--- a/spec/features/public/contacts_index_spec.rb
+++ b/spec/features/public/contacts_index_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Contacts index page" do
   let!(:hmrc)          { create :organisation, :title => "HM Revenue & Customs" }
-  let!(:contact)       { create(:contact, :with_phone_numbers, :with_contact_group, organisation: hmrc) }
+  let!(:contact)       { create(:contact, :with_phone_numbers, :with_contact_group, title: "General", organisation: hmrc) }
   let!(:contact2)      { create(:contact, :with_phone_numbers, :with_contact_group, organisation: hmrc) }
   let!(:other_contact) { create(:contact, :with_phone_numbers, :with_contact_group) }
 
@@ -14,5 +14,13 @@ describe "Contacts index page" do
 
     expect(page).to have_link(contact.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact.slug}")
     expect(page).to have_link(contact2.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact2.slug}")
+  end
+
+  it "should handle filtering using the older parameter name" do
+    # This could happen if users followed an old bookmark or link
+    visit "/government/organisations/hm-revenue-customs/contact?search%5Bname%5D=general"
+
+    expect(page).to have_link(contact.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact.slug}")
+    expect(page).to_not have_link(contact2.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact2.slug}")
   end
 end


### PR DESCRIPTION
This issue is causing significant number of errors in production.

I renamed the search parameter in c439191e5bf24366fdfc961dcd7f162de0f09497

Unfortunately, many links exist which use the old parameter name, and when the
old parameter name is supplied, Searchlight raises an error.

The alternatives to this would be:
* revert the changes, go back to the old name and hope users don't bookmark the
  new name
* discard the old parameter
* redirect requests to use the new parameter