### PR TITLE
Org contact id for finders & rake task for publishing Finders.

### DIFF
--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -91,7 +91,7 @@ private
   end
 
   def organisations
-    []
+    [organisation.content_id].compact
   end
 
   def public_updated_at

--- a/app/tasks/import_organisations.rb
+++ b/app/tasks/import_organisations.rb
@@ -26,7 +26,8 @@ private
       title: organisation_data.title,
       format: organisation_data.format,
       abbreviation: organisation_data.details.abbreviation,
-      govuk_status: organisation_data.details.govuk_status
+      govuk_status: organisation_data.details.govuk_status,
+      content_id: organisation_data.details.content_id,
     }
     organisation.update_attributes!(update_data)
   end

--- a/db/migrate/20150114102401_add_content_id_to_organisations.rb
+++ b/db/migrate/20150114102401_add_content_id_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddContentIdToOrganisations < ActiveRecord::Migration
+  def change
+    add_column :organisations, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150112114153) do
+ActiveRecord::Schema.define(version: 20150114102401) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 20150112114153) do
     t.datetime "updated_at"
     t.string   "ancestry"
     t.string   "contact_index_content_id"
+    t.string   "content_id"
   end
 
   add_index "organisations", ["ancestry"], name: "index_organisations_on_ancestry", using: :btree

--- a/lib/tasks/finders.rake
+++ b/lib/tasks/finders.rake
@@ -1,0 +1,11 @@
+namespace :finders do
+  desc "Publish Finders for each Org's Contacts"
+  task :publish => :environment do
+    Organisation.all.each do |org|
+      if org.contact_groups.any?
+        presenter = ContactsFinderPresenter.new(org)
+        Contacts::Publisher.publish(presenter)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relies on https://github.com/alphagov/contacts-admin/pull/183 and https://github.com/alphagov/whitehall/pull/1950 being merged first.

This PR contains the work necessary to tag Org Contacts Finders to the correct Org. It does this by retrieving the content_id from the Whitehall Org API and sending it to the Publishing API with the Contacts Finder Content Item.