### PR TITLE
Disable Finder publishing for now

### DIFF
--- a/app/models/contact_group.rb
+++ b/app/models/contact_group.rb
@@ -7,7 +7,10 @@ class ContactGroup < ActiveRecord::Base
 
   belongs_to :organisation
 
-  after_save :publish_finder
+  # The line below is commented out in order to disable publishing of
+  # Finders until we have Contacts within the Elastic Search index.
+  #
+  # after_save :publish_finder
 
   friendly_id :title, use: :history
 


### PR DESCRIPTION
Publishing the Finder will take over the Index page for Contacts and as they don't yet exist in the search index there's then no way to browse them.

This commit disables the Finder publishing temporarily by commenting it out and explaining why it is commented.