### PR TITLE
Use new facet structure

### DIFF
--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -57,7 +57,9 @@ private
       {
         key: "contact_group",
         name: "Topic",
-        type: "multi-select",
+        filterable: true,
+        type: "text",
+        display_in_result_metadata: true,
         preposition: "in topic",
         allowed_values: contact_groups_to_facet,
       }


### PR DESCRIPTION
With the changes in Finder Frontend to remove all the format specific code, Contacts won't have any facets. This change sets the new attrs of `filterable` and `display_as_result_metadata` for the Topic facet. 

Don't merge before https://github.com/alphagov/finder-frontend/pull/148.