### PR TITLE
Finder filter restriction in content item

### DIFF
--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -47,7 +47,12 @@ private
   def details
     {
       document_noun: "contact",
-      document_type: "contact",
+      filter: {
+        document_type: "contact",
+        organisations: [
+          organisation.slug
+        ],
+      },
       facets: facets,
     }
   end


### PR DESCRIPTION
As Finder Frontend becomes more generic, we want to be able to specify how we restrict the default filter. This commit adds it to the content item when it is published. We also move the `document_type` into the `filter` as `filter_document_type`. This PR relates to the work in https://github.com/alphagov/finder-frontend/pull/161.