### PR TITLE
Don't generate rcov coverage data by default

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,5 +6,5 @@ export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop db:create db:schema:load
 bundle exec rake assets:precompile --trace
-bundle exec rake ci:setup:rspec spec --trace
+COVERAGE=on bundle exec rake ci:setup:rspec spec --trace
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 ENV["RAILS_ENV"] ||= "test"
 
-require "simplecov"
-require "simplecov-rcov"
+if( ENV['COVERAGE'] == 'on' )
+  require "simplecov"
+  require "simplecov-rcov"
 
-SimpleCov.start "rails"
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start "rails"
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+end
 
 require File.expand_path("../../config/environment", __FILE__)
 


### PR DESCRIPTION
Only generate it on CI build, or if run with COVERAGE=on.

Generating the coverage files takes a non-trivial time after a successful run
of the test suite, which can be annoying if you want to get on with running
another command.

Copied from: https://github.com/alphagov/content-store/pull/102 and the simplecov-rcov documentation: https://github.com/fguillen/simplecov-rcov#usage