### PR TITLE
Fix `undefined local variable` errors in the update org slugs rake task

### DIFF
--- a/lib/tasks/update_organisation_slug.rake
+++ b/lib/tasks/update_organisation_slug.rake
@@ -3,5 +3,5 @@ task :update_organisation_slug, [:old_slug, :new_slug] => :environment do |_task
   logger = Logger.new(STDOUT)
   logger.error("You must specify [old_slug,new_slug]") unless args.old_slug.present? && args.new_slug.present?
 
-  exit(1) unless OrganisationSlugUpdater.new(old_slug, new_slug, logger).call
+  exit(1) unless OrganisationSlugUpdater.new(args.old_slug, args.new_slug, logger).call
 end


### PR DESCRIPTION
- On second-line while running each of the rake tasks within each of
  the apps as per the guide to change an organisation slug, we came
  across this one that didn't work. Fix it by referencing
  `args.old_slug` etc, because they come from command-line arguments.