### PR TITLE
govuk-content-schema tests for finders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,4 +59,5 @@ group :test do
   gem "simplecov"
   gem "simplecov-rcov"
   gem 'webmock', '1.17.3'
+  gem 'json-schema', '2.5.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
+    addressable (2.3.7)
     airbrake (3.1.15)
       builder
       multi_json
@@ -127,6 +127,8 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     jwt (1.0.0)
     kgio (2.9.2)
     kramdown (0.13.8)
@@ -330,6 +332,7 @@ DEPENDENCIES
   govspeak (= 1.2.3)
   govuk_admin_template (= 1.4.3)
   govuk_frontend_toolkit (= 0.46.1)
+  json-schema (= 2.5.1)
   lrucache (= 0.1.4)
   mlanett-redis-lock (= 0.2.6)
   mysql2 (~> 0.3.13)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ run against a local version of static you need to set `STATIC_DEV` to
 
 ## Tests
 
+The tests in this project rely upon [govuk-content-schemas](http://github.com/alphagov/govuk-content-schemas). By default these should be in the parent directory, otherwise you can specify their location with the `GOVUK_CONTENT_SCHEMAS_PATH` environment variable.
+
+Assuming you already have govuk-content-schemas cloned:
     ```
     bundle exec rake db:test:prepare RAILS_ENV=test
     bundle exec rspec .

--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -21,6 +21,7 @@ class ContactsFinderPresenter
         topics: [],
         related: [],
       },
+      locale: "en",
     }
   end
 
@@ -63,7 +64,7 @@ private
         name: "Topic",
         filterable: true,
         type: "text",
-        display_in_result_metadata: true,
+        display_as_result_metadata: true,
         preposition: "in topic",
         allowed_values: contact_groups_to_facet,
       }

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -xe
+export DISPLAY=:99
+export GOVUK_APP_DOMAIN=test.alphagov.co.uk
+export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+env
+
+function github_status {
+  STATUS="$1"
+  MESSAGE="$2"
+  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "Verify contacts-admin against content schemas" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status failure "failed on Jenkins"
+  exit "${code}"
+}
+
+trap "error_handler ${LINENO}" ERR
+github_status pending "is running on Jenkins"
+
+# Ensure there are no artefacts left over from previous builds
+git clean -fdx
+
+# Clone govuk-content-schemas dependency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+cd tmp/govuk-content-schemas
+git checkout $SCHEMA_GIT_COMMIT
+cd ../..
+
+time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+# TODO as schemas are added for them, change this to include more formats
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec spec/presenters/contacts_finder_presenter_spec.rb
+
+EXIT_STATUS=$?
+echo "EXIT STATUS: $EXIT_STATUS"
+
+if [ "$EXIT_STATUS" == "0" ]; then
+  github_status success "succeeded on Jenkins"
+else
+  github_status failure "failed on Jenkins"
+fi
+
+exit $EXIT_STATUS

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,5 +6,10 @@ export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop db:create db:schema:load
 bundle exec rake assets:precompile --trace
-COVERAGE=on bundle exec rake ci:setup:rspec spec --trace
+
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+
+GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas COVERAGE=on bundle exec rake ci:setup:rspec spec --trace
 

--- a/spec/presenters/contacts_finder_presenter_spec.rb
+++ b/spec/presenters/contacts_finder_presenter_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe ContactsFinderPresenter do
+  include GovukContentSchemaHelpers
 
   let(:group) { create :contact_group, :with_organisation }
 
@@ -9,5 +10,6 @@ describe ContactsFinderPresenter do
 
     expect(presented[:title]).to             include(group.organisation.title)
     expect(presented[:public_updated_at]).to eq(group.updated_at.to_s)
+    assert_valid_against_schema(presented, 'finder')
   end
 end

--- a/spec/support/govuk_content_schema_helpers.rb
+++ b/spec/support/govuk_content_schema_helpers.rb
@@ -1,0 +1,44 @@
+require 'json-schema'
+
+class GovukContentSchema
+
+  class ImproperlyConfiguredError < RuntimeError; end
+
+  def self.schema_path(schema_name)
+    Rails.root.join("#{self.govuk_content_schemas_path}/formats/#{schema_name}/publisher/schema.json").to_s
+  end
+
+  def self.govuk_content_schemas_path
+    ENV['GOVUK_CONTENT_SCHEMAS_PATH'] || '../govuk-content-schemas'
+  end
+
+  class Validator
+    def initialize(schema_name, document)
+      @schema_path = GovukContentSchema.schema_path(schema_name)
+      if !Pathname(GovukContentSchema.govuk_content_schemas_path).exist?
+        message = "Dependency govuk-content-schemas cannot be found at: #{GovukContentSchema.govuk_content_schemas_path}."
+        message += " Clone it to that directory, or set GOVUK_CONTENT_SCHEMAS_PATH (see README.md for details)."
+        raise ImproperlyConfiguredError, message
+      elsif !File.exists?(@schema_path)
+        raise ImproperlyConfiguredError, "Schema file not found: #{@schema_path}."
+      end
+      @document = document
+    end
+
+    def valid?
+      errors.empty?
+    end
+
+    def errors
+      @errors ||= JSON::Validator.fully_validate(@schema_path, @document)
+    end
+  end
+end
+
+
+module GovukContentSchemaHelpers
+  def assert_valid_against_schema(content_item_hash, format)
+    validator = GovukContentSchema::Validator.new(format, content_item_hash.to_json)
+    assert validator.valid?, "JSON not valid against #{format} schema: #{validator.errors.to_s}"
+  end
+end


### PR DESCRIPTION
This is largely copied from Whitehall.

We plan to work out a way of sharing the Ruby code, but a little bit of duplication feels sensible at this stage.

Once contacts are defined in govuk-content-schemas, they can be tested too.