### PR TITLE
Don't send empty arrays to publishing API

### DIFF
--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -18,8 +18,6 @@ class ContactsFinderPresenter
       details: details,
       links: {
         organisations: organisations,
-        topics: [],
-        related: [],
       },
       locale: "en",
     }


### PR DESCRIPTION
There's no point always sending empty arrays to publishing API for fields
which are optional.