### PR TITLE
Make specs involving govspeak less flaky

### DIFF
--- a/spec/presenters/contact_form_links_presenter_spec.rb
+++ b/spec/presenters/contact_form_links_presenter_spec.rb
@@ -1,14 +1,13 @@
 require "spec_helper"
 
 describe ContactFormLinksPresenter do
-  let(:form_link) { create :contact_form_link }
+  let(:form_link) { create(:contact_form_link, title: "Abc", description: "* xyz") }
 
   it "transforms a contact form link to the correct format" do
     presented = ContactFormLinksPresenter.new([form_link]).present.first
 
-    expect(presented[:title]).to eq(form_link.title)
-
-    govspeak_description = "<ul>\n<li>#{form_link.description.sub("\* ", "")}</li>\n</ul>"
-    expect(presented[:description]).to eq(govspeak_description)
+    expect(presented[:title]).to eq("Abc")
+    actual_presented_description_text = Nokogiri(presented[:description]).at_css("ul li").text
+    expect(actual_presented_description_text).to eq("xyz")
   end
 end

--- a/spec/presenters/contact_groups_presenter_spec.rb
+++ b/spec/presenters/contact_groups_presenter_spec.rb
@@ -10,9 +10,9 @@ describe ContactGroupsPresenter do
     expect(presented[:organisation]).to eq(group.organisation.as_json)
 
     govspeak_description = "<p>#{group.description}</p>"
-    expect(presented[:description]).to eq(govspeak_description)
+    expect(presented[:description].strip).to eq(govspeak_description)
 
     govspeak_description = "<p>#{group.contacts.first.description}</p>"
-    expect(presented[:contacts].first[:description]).to eq(govspeak_description)
+    expect(presented[:contacts].first[:description].strip).to eq(govspeak_description)
   end
 end

--- a/spec/presenters/email_addresses_presenter_spec.rb
+++ b/spec/presenters/email_addresses_presenter_spec.rb
@@ -10,6 +10,6 @@ describe EmailAddressesPresenter do
     expect(presented[:email]).to eq(email.email)
 
     govspeak_description = "<p>#{email.description}</p>"
-    expect(presented[:description]).to eq(govspeak_description)
+    expect(presented[:description].strip).to eq(govspeak_description)
   end
 end

--- a/spec/presenters/phone_numbers_presenter_spec.rb
+++ b/spec/presenters/phone_numbers_presenter_spec.rb
@@ -14,12 +14,12 @@ describe PhoneNumbersPresenter do
     expect(presented[:number]).to eq(phone.number)
 
     govspeak_description = "<p>#{phone.description}</p>"
-    expect(presented[:description]).to eq(govspeak_description)
+    expect(presented[:description].strip).to eq(govspeak_description)
 
     govspeak_open_hours = "<p>#{phone.open_hours}</p>"
-    expect(presented[:open_hours]).to eq(govspeak_open_hours)
+    expect(presented[:open_hours].strip).to eq(govspeak_open_hours)
 
     govspeak_best_time = "<p>#{phone.best_time_to_call}</p>"
-    expect(presented[:best_time_to_call]).to eq(govspeak_best_time)
+    expect(presented[:best_time_to_call].strip).to eq(govspeak_best_time)
   end
 end

--- a/spec/presenters/post_addresses_presenter_spec.rb
+++ b/spec/presenters/post_addresses_presenter_spec.rb
@@ -16,6 +16,6 @@ describe PostAddressesPresenter do
     expect(presented[:world_location]).to eq(post.world_location.title)
 
     govspeak_description = "<p>#{post.description}</p>"
-    expect(presented[:description]).to eq(govspeak_description)
+    expect(presented[:description].strip).to eq(govspeak_description)
   end
 end


### PR DESCRIPTION
These specs behave differently, depending on which version of the parsing
library is used by Nokogiri. These libraries vary depending on the version
of Ubuntu running on the system, meaning that govspeak fields can have
extra whitespace or newlines.

/cc @fofr 