### PR TITLE
Add meta description tag to contact index page

### DIFF
--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,5 +1,9 @@
 <% page_class 'contacts-page documents-index' %>
 
+<% content_for :extra_headers do %>
+  <meta name='description' content='Contact details and helplines for enquiries with HMRC' />
+<% end %>
+
 <header class="block headings-block">
   <div class="inner-block floated-children">
     <div class="heading-big">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <%= stylesheet_link_tag "frontend/base-ie8.css" %><script>var ieVersion = 8;</script>
   <![endif]-->
   <%= csrf_meta_tags %>
+  <%= yield :extra_headers %>
 </head>
 <body class="hmrc-contacts-body">
 <% unless local_assigns[:show_breadcrumbs] %>

--- a/spec/features/public/contacts_index_spec.rb
+++ b/spec/features/public/contacts_index_spec.rb
@@ -62,4 +62,10 @@ feature "Public Contacts index page" do
     expect(page).to have_link(contact.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact.slug}")
     expect(page).to_not have_link(contact2.title, :href => "/government/organisations/#{hmrc.slug}/contact/#{contact2.slug}")
   end
+
+  it "should have a meta-description to aid external search engine results" do
+    visit "/government/organisations/#{hmrc.slug}/contact"
+
+    expect(page).to have_selector("meta[name='description'][content='Contact details and helplines for enquiries with HMRC']", visible: false)
+  end
 end


### PR DESCRIPTION
Part of improving search result snipperts shown on external search
engines.

The lack of a meta-description tag makes some search result snippets
unhelpful, confusing, or misleading. Ticket:
https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types