### PR TITLE
Send `public_timestamp` to rummager

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -59,7 +59,7 @@ class Contact < ActiveRecord::Base
       format: "contact",
       indexable_content: "#{title} #{description} #{contact_groups.map(&:title).join}",
       organisations: [organisation.slug],
-      last_update: self.updated_at,
+      public_timestamp: self.updated_at,
     }
   end
 

--- a/spec/features/steps/admin/site_search_steps.rb
+++ b/spec/features/steps/admin/site_search_steps.rb
@@ -7,7 +7,7 @@ module Admin
       expected_json = contact.to_indexed_json.merge(
         _type: 'contact',
       )
-      # export to JSON so that the last_update timestamp is in a string and can
+      # export to JSON so that the public_timestamp timestamp is in a string and can
       # be compared to the JSON captured by Webmock
       expected_json = JSON.parse(expected_json.to_json)
       assert_rummager_posted_item(expected_json)

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -63,7 +63,7 @@ describe Contact do
         format:            'contact',
         indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
         organisations:     ['bowie'],
-        last_update:       contact.updated_at,
+        public_timestamp:  contact.updated_at,
       }
 
       expect(contact.to_indexed_json).to eql(expected)


### PR DESCRIPTION
`last_update`  and `public_timestamp` mean the same thing in rummager.

Current behaviour of rummager is that if `public_timestamp` is empty, `last_update` [gets copied into `public_timestamp`](https://github.com/alphagov/rummager/blob/d3637f348612b76ee4de8d2c01048af39ea2a568/lib/indexer/document_preparer.rb#L46).

This commit changes what is sent to rummager so that we populate `public_timestamp` directly and can remove the special field and special code from rummager.

Trello: https://trello.com/c/yY2jFlXl

Previous PRs: https://github.com/alphagov/hmrc-manuals-api/pull/106 & https://github.com/alphagov/specialist-publisher/pull/545
