### PR TITLE
Scripts for redirecting gone contacts

### DIFF
--- a/app/interactors/admin/destroy_and_redirect_contact.rb
+++ b/app/interactors/admin/destroy_and_redirect_contact.rb
@@ -1,0 +1,29 @@
+module Admin
+  class DestroyAndRedirectContact
+    attr_reader :contact, :redirect_to_location
+
+    def initialize(contact, redirect_to_location)
+      @contact = contact
+      @redirect_to_location = redirect_to_location
+    end
+
+    def destroy_and_redirect
+      contact.transaction do
+        # Overwrite with a redirect item in content-store
+        ::Contacts.publishing_api.put_content_item(contact.link, redirect_content_item)
+
+        # Remove from site search
+        rummager_id = contact.link.gsub(%r{^/}, '')
+        ::Contacts.rummager_client.delete_document("contact", rummager_id)
+
+        # Remove from our database
+        contact.destroy
+      end
+    end
+
+  private
+    def redirect_content_item
+      ContactRedirectPresenter.new(contact, redirect_to_location).present
+    end
+  end
+end

--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class ContactGonePresenter
   include GovspeakHelper
 
@@ -15,6 +17,12 @@ class ContactGonePresenter
       routes: [
         { path: contact.link, type: "exact" }
       ],
+      content_id: content_id,
     }
+  end
+
+private
+  def content_id
+    @_content_id ||= SecureRandom.uuid
   end
 end

--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -14,6 +14,7 @@ class ContactGonePresenter
       format: "gone",
       publishing_app: "contacts",
       update_type: "major",
+      base_path: contact.link,
       routes: [
         { path: contact.link, type: "exact" }
       ],

--- a/app/presenters/contact_redirect_presenter.rb
+++ b/app/presenters/contact_redirect_presenter.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class ContactRedirectPresenter
   attr_reader :contact, :redirect_to_location
 
@@ -19,6 +21,12 @@ class ContactRedirectPresenter
           destination: redirect_to_location
         }
       ],
+      content_id: content_id,
     }
+  end
+
+private
+  def content_id
+    @_content_id ||= SecureRandom.uuid
   end
 end

--- a/app/presenters/contact_redirect_presenter.rb
+++ b/app/presenters/contact_redirect_presenter.rb
@@ -1,0 +1,24 @@
+class ContactRedirectPresenter
+  attr_reader :contact, :redirect_to_location
+
+  def initialize(contact, redirect_to_location)
+    @contact = contact
+    @redirect_to_location = redirect_to_location
+  end
+
+  def present
+    {
+      format: "redirect",
+      publishing_app: "contacts",
+      update_type: "major",
+      base_path: contact.link,
+      redirects: [
+        {
+          path: contact.link,
+          type: "exact",
+          destination: redirect_to_location
+        }
+      ],
+    }
+  end
+end

--- a/lib/redirector_for_gone_contact.rb
+++ b/lib/redirector_for_gone_contact.rb
@@ -1,0 +1,90 @@
+require 'gds_api/content_store'
+
+class RedirectorForGoneContact
+
+  def initialize(contact_slug:, organisation_slug:, redirect_to_location:)
+    @contact_slug = contact_slug
+    @organisation_slug = organisation_slug
+    @redirect_to_location = redirect_to_location
+  end
+
+  def redirect_gone_contact
+    if contact_already_exists?
+      Failure.new(:contact_exists, contact.link)
+    elsif contact_not_published?
+      Failure.new(:unpublished_contact, contact.link)
+    elsif contact_not_gone?
+      Failure.new(:not_gone, contact.link, existing: published_contact)
+    elsif redirect_failed?
+      Failure.new(:redirect_failed, contact.link, error: redirect_contact_response)
+    else
+      Success.new(contact.link)
+    end
+  rescue GdsApi::HTTPErrorResponse => e
+    Failure.new(:redirect_failed, contact.link, error: e)
+  end
+
+  def contact_already_exists?
+    Contact.exists?(contact_slug)
+  end
+
+  def contact_not_published?
+    published_contact.nil?
+  end
+
+  def contact_not_gone?
+    published_contact.format != 'gone'
+  end
+
+  def redirect_failed?
+    redirect_contact_response.code != 200
+  end
+
+  class Success
+    attr_reader :full_contact_path
+    def initialize(full_contact_path)
+      @full_contact_path = full_contact_path
+    end
+
+    def successful?; true; end
+  end
+
+  class Failure
+    attr_reader :full_contact_path, :reason, :existing, :error
+    def initialize(reason, full_contact_path, existing: nil, error: nil)
+      @reason = reason
+      @existing = existing
+      @error = error
+      @full_contact_path = full_contact_path
+    end
+    def successful?; false; end
+  end
+
+private
+  attr_reader :contact_slug, :organisation_slug, :redirect_to_location
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.current.find('content-store'))
+  end
+
+  def organisation
+    @organisation ||= Organisation.find(organisation_slug)
+  end
+
+  def contact
+    @contact ||= Contact.new(slug: contact_slug, organisation: organisation)
+  end
+
+  def published_contact
+    @published_contact ||= content_store.content_item(contact.link)
+  end
+
+  def redirect_contact_response
+    @redirect_contact_response ||= ::Contacts.publishing_api.put_content_item(contact.link, redirect_content_item)
+  end
+
+  def redirect_content_item
+    @redirect_content_item ||= ContactRedirectPresenter.new(contact, redirect_to_location).present
+  end
+
+end

--- a/lib/redirector_for_gone_contact.rb
+++ b/lib/redirector_for_gone_contact.rb
@@ -15,6 +15,8 @@ class RedirectorForGoneContact
       Failure.new(:unpublished_contact, contact.link)
     elsif contact_not_gone?
       Failure.new(:not_gone, contact.link, existing: published_contact)
+    elsif contact_not_published_by_contacts?
+      Failure.new(:not_published_by_contacts, contact.link, existing: published_contact)
     elsif redirect_failed?
       Failure.new(:redirect_failed, contact.link, error: redirect_contact_response)
     else
@@ -34,6 +36,10 @@ class RedirectorForGoneContact
 
   def contact_not_gone?
     published_contact.format != 'gone'
+  end
+
+  def contact_not_published_by_contacts?
+    published_contact.publishing_app != 'contacts'
   end
 
   def redirect_failed?

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -80,6 +80,8 @@ namespace :contacts do
           puts "Contact #{result.full_contact_path} has never been published, consider creating it first then using 'rake contacts:remove_with_redirect'"
         when :not_gone
           puts "Contact #{result.full_contact_path} is not 'gone' - it's published as a #{result.existing.format}."
+        when :not_published_by_contacts
+          puts "Contact #{result.full_contact_path} is 'gone' but it wasn't published by contacts-admin - it was published by #{result.existing.publishing_app}."
         when :redirect_failed
           puts "Contact #{result.full_contact_path} could not be redirected to #{args.redirect_to_location} (Publishing API Failure - #{result.error})"
         else

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -37,4 +37,23 @@ namespace :contacts do
       ::Contacts.publishing_api.put_content_item(contact.link, p.present)
     end
   end
+
+  desc "Remove a contact and redirect it"
+  task :remove_with_redirect, [:contact_slug, :redirect_to_location] => :environment do |_task, args|
+    if args.contact_slug.blank? || args.redirect_to_location.blank?
+      puts "Usage: rake contacts:remove_with_redirect[contact-to-remove-slug,path-to-redirect-to]"
+    else
+      contact = Contact.find_by_slug(args.contact_slug)
+      if contact.nil?
+        puts "Contact #{args.contact_slug} doesn't exist."
+      else
+        print "Contact #{contact.link} removed with redirect to #{args.redirect_to_location} "
+        if Admin::DestroyAndRedirectContact.new(contact, args.redirect_to_location).destroy_and_redirect
+          puts "SUCCESS"
+        else
+          puts "ERROR"
+        end
+      end
+    end
+  end
 end

--- a/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
+++ b/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Admin::DestroyAndRedirectContact do
+  describe "#destroy_and_redirect" do
+    let(:contact) { create :contact }
+    let(:redirect_to_location) { '/foo/bar/baz' }
+    subject!(:interactor) { described_class.new(contact, redirect_to_location) }
+
+    it 'removes the item from rummager' do
+      ::Contacts.rummager_client.
+        should_receive(:delete_document).
+        with("contact", contact.link.gsub(%r{^/},''))
+
+      subject.destroy_and_redirect
+    end
+
+    context "rummager does not throw an error" do
+      before do
+        stub_any_rummager_delete
+      end
+
+      it "destroys the contact" do
+        subject.destroy_and_redirect
+
+        expect(Contact.exists?(contact.id)).to be_false
+      end
+
+      it "replaces the item in content store with a redirect item" do
+        ::Contacts.publishing_api.
+          should_receive(:put_content_item).
+          with(
+            contact.link,
+            hash_including(
+              format: 'redirect',
+              redirects: [
+                hash_including(
+                  destination: redirect_to_location
+                )
+              ]
+            )
+          )
+
+        subject.destroy_and_redirect
+      end
+    end
+  end
+end

--- a/spec/lib/redirector_for_gone_contact_spec.rb
+++ b/spec/lib/redirector_for_gone_contact_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+require 'redirector_for_gone_contact'
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/publishing_api'
+
+describe RedirectorForGoneContact do
+  let(:organisation) { create :organisation, title: 'Ministry of Hats' }
+  let(:organisation_slug) { organisation.slug }
+  let(:redirect_to_location) { '/find-my-nearest/hat-shop' }
+
+  subject(:redirector) do
+    RedirectorForGoneContact.new(
+      contact_slug: contact_slug,
+      organisation_slug: organisation_slug,
+      redirect_to_location: redirect_to_location
+    )
+  end
+
+  context 'when the contact_slug refers to a contact in the db' do
+    let!(:contact) { create :contact, title: 'Chief Milliners Office', organisation: organisation }
+    let(:contact_slug) { contact.slug }
+
+    it 'is not successful when doing the redirect' do
+      expect(subject.redirect_gone_contact).not_to be_successful
+    end
+
+    it 'provides a reason for the failure' do
+      expect(subject.redirect_gone_contact.reason).to eq(:contact_exists)
+    end
+
+    it 'does not publish a redirect' do
+      ::Contacts.publishing_api.should_not_receive(:put_content_item)
+      subject.redirect_gone_contact
+    end
+  end
+
+  context 'when the contact_slug does not refer to a contact in the db' do
+    include GdsApi::TestHelpers::ContentStore
+
+    let(:contact_slug) { 'chief-milliners-office' }
+    let(:path_in_content_store) { "/government/organisations/#{organisation_slug}/contact/#{contact_slug}" }
+
+    context 'and does not refer to something in the content-store' do
+      before { content_store_does_not_have_item path_in_content_store }
+
+      it 'is not successful when doing the redirect' do
+        expect(subject.redirect_gone_contact).not_to be_successful
+      end
+
+      it 'provides a reason for the failure' do
+        expect(subject.redirect_gone_contact.reason).to eq(:unpublished_contact)
+      end
+
+      it 'does not publish a redirect' do
+        ::Contacts.publishing_api.should_not_receive(:put_content_item)
+        subject.redirect_gone_contact
+      end
+    end
+
+    context 'and refers to an non-"gone" object in the content-store' do
+      before { content_store_has_item path_in_content_store }
+
+      it 'is not successful when doing the redirect' do
+        expect(subject.redirect_gone_contact).not_to be_successful
+      end
+
+      it 'provides a reason for the failure' do
+        expect(subject.redirect_gone_contact.reason).to eq(:not_gone)
+      end
+
+      it 'does not publish a redirect' do
+        ::Contacts.publishing_api.should_not_receive(:put_content_item)
+        subject.redirect_gone_contact
+      end
+    end
+
+    context 'and refers to a "gone" object in the content-store' do
+      include GdsApi::TestHelpers::PublishingApi
+
+      let(:gone_item) { content_item_for_base_path(path_in_content_store).merge("format" => "gone") }
+
+      before { content_store_has_item path_in_content_store, gone_item }
+
+      it 'sends a redirect to the publishing-api for the contact' do
+        subject.redirect_gone_contact
+
+        assert_publishing_api_put_item(
+          path_in_content_store,
+          ->(request) do
+            data = JSON.parse(request.body)
+            # RSpec 2.14 doesn't have a fluent interface for this kind of match
+            expect(data).to have_key('format')
+            expect(data['format']).to eq('redirect')
+            expect(data).to have_key('redirects')
+            expect(data['redirects'].size).to eq(1)
+            redirect = data['redirects'].first
+            expect(redirect).to have_key('destination')
+            expect(redirect['destination']).to eq(redirect_to_location)
+          end
+        )
+      end
+
+      context 'and communicating with the publishing-api is succesful' do
+        before { stub_default_publishing_api_put }
+
+        it 'is successful when doing the redirect' do
+          expect(subject.redirect_gone_contact).to be_successful
+        end
+      end
+
+      context 'and communicating with the publishing-api fails' do
+        before { stub_default_publishing_api_put.to_return(status: 422, body: "Uh oh!") }
+
+        it 'is unsuccessful when doing the redirect' do
+          expect(subject.redirect_gone_contact).not_to be_successful
+        end
+
+        it 'provides a reason for the failure' do
+          expect(subject.redirect_gone_contact.reason).to eq(:redirect_failed)
+        end
+
+        it 'includes the failed response from the api' do
+          expect(subject.redirect_gone_contact.error).to be_a(GdsApi::HTTPErrorResponse)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/redirector_for_gone_contact_spec.rb
+++ b/spec/lib/redirector_for_gone_contact_spec.rb
@@ -77,50 +77,83 @@ describe RedirectorForGoneContact do
     context 'and refers to a "gone" object in the content-store' do
       include GdsApi::TestHelpers::PublishingApi
 
-      let(:gone_item) { content_item_for_base_path(path_in_content_store).merge("format" => "gone") }
-
-      before { content_store_has_item path_in_content_store, gone_item }
-
-      it 'sends a redirect to the publishing-api for the contact' do
-        subject.redirect_gone_contact
-
-        assert_publishing_api_put_item(
-          path_in_content_store,
-          ->(request) do
-            data = JSON.parse(request.body)
-            # RSpec 2.14 doesn't have a fluent interface for this kind of match
-            expect(data).to have_key('format')
-            expect(data['format']).to eq('redirect')
-            expect(data).to have_key('redirects')
-            expect(data['redirects'].size).to eq(1)
-            redirect = data['redirects'].first
-            expect(redirect).to have_key('destination')
-            expect(redirect['destination']).to eq(redirect_to_location)
-          end
-        )
-      end
-
-      context 'and communicating with the publishing-api is succesful' do
-        before { stub_default_publishing_api_put }
-
-        it 'is successful when doing the redirect' do
-          expect(subject.redirect_gone_contact).to be_successful
+      context 'not published by contacts' do
+        let(:gone_item) do
+          content_item_for_base_path(path_in_content_store).
+            merge(
+              "format" => "gone",
+              "publishing_app" => 'some-other-app'
+            )
         end
-      end
 
-      context 'and communicating with the publishing-api fails' do
-        before { stub_default_publishing_api_put.to_return(status: 422, body: "Uh oh!") }
+        before { content_store_has_item path_in_content_store, gone_item }
 
-        it 'is unsuccessful when doing the redirect' do
+        it 'is not successful when doing the redirect' do
           expect(subject.redirect_gone_contact).not_to be_successful
         end
 
         it 'provides a reason for the failure' do
-          expect(subject.redirect_gone_contact.reason).to eq(:redirect_failed)
+          expect(subject.redirect_gone_contact.reason).to eq(:not_published_by_contacts)
         end
 
-        it 'includes the failed response from the api' do
-          expect(subject.redirect_gone_contact.error).to be_a(GdsApi::HTTPErrorResponse)
+        it 'does not publish a redirect' do
+          ::Contacts.publishing_api.should_not_receive(:put_content_item)
+          subject.redirect_gone_contact
+        end
+      end
+
+      context 'published by contacts' do
+        let(:gone_item) do
+          content_item_for_base_path(path_in_content_store).
+            merge(
+              "format" => "gone",
+              "publishing_app" => 'contacts'
+            )
+        end
+
+        before { content_store_has_item path_in_content_store, gone_item }
+
+        it 'sends a redirect to the publishing-api for the contact' do
+          subject.redirect_gone_contact
+
+          assert_publishing_api_put_item(
+            path_in_content_store,
+            ->(request) do
+              data = JSON.parse(request.body)
+              # RSpec 2.14 doesn't have a fluent interface for this kind of match
+              expect(data).to have_key('format')
+              expect(data['format']).to eq('redirect')
+              expect(data).to have_key('redirects')
+              expect(data['redirects'].size).to eq(1)
+              redirect = data['redirects'].first
+              expect(redirect).to have_key('destination')
+              expect(redirect['destination']).to eq(redirect_to_location)
+            end
+          )
+        end
+
+        context 'and communicating with the publishing-api is succesful' do
+          before { stub_default_publishing_api_put }
+
+          it 'is successful when doing the redirect' do
+            expect(subject.redirect_gone_contact).to be_successful
+          end
+        end
+
+        context 'and communicating with the publishing-api fails' do
+          before { stub_default_publishing_api_put.to_return(status: 422, body: "Uh oh!") }
+
+          it 'is unsuccessful when doing the redirect' do
+            expect(subject.redirect_gone_contact).not_to be_successful
+          end
+
+          it 'provides a reason for the failure' do
+            expect(subject.redirect_gone_contact.reason).to eq(:redirect_failed)
+          end
+
+          it 'includes the failed response from the api' do
+            expect(subject.redirect_gone_contact.error).to be_a(GdsApi::HTTPErrorResponse)
+          end
         end
       end
     end

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -13,6 +13,7 @@ describe ContactGonePresenter do
     expect(payload[:publishing_app]).to eq("contacts")
     expect(payload[:update_type]).to eq("major")
     expect(payload[:routes].first[:path]).to eq(contact.link)
+    expect(payload[:base_path]).to eq(contact.link)
   end
 
   it 'includes a content_id that is not the same as contact.content_id' do

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -2,13 +2,20 @@ require "spec_helper"
 
 describe ContactGonePresenter do
   let(:contact) { create :contact }
+  subject(:presenter) { described_class.new(contact) }
+  let(:payload) { subject.present }
 
   it "transforms a contact to the correct format" do
-    payload = ContactGonePresenter.new(contact).present
-
     expect(payload[:format]).to eq('gone')
     expect(payload[:publishing_app]).to eq("contacts")
     expect(payload[:update_type]).to eq("major")
     expect(payload[:routes].first[:path]).to eq(contact.link)
+  end
+
+  it 'includes a content_id that is not the same as contact.content_id' do
+    content_id = payload[:content_id]
+
+    expect(content_id).not_to be_blank
+    expect(content_id).not_to eq(contact.content_id)
   end
 end

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
+require 'govuk-content-schema-test-helpers/rspec_matchers'
 
 describe ContactGonePresenter do
+  include GovukContentSchemaTestHelpers::RSpecMatchers
+
   let(:contact) { create :contact }
   subject(:presenter) { described_class.new(contact) }
   let(:payload) { subject.present }
@@ -17,5 +20,9 @@ describe ContactGonePresenter do
 
     expect(content_id).not_to be_blank
     expect(content_id).not_to eq(contact.content_id)
+  end
+
+  it 'is a valid "gone" item according to the schema' do
+    expect(payload.to_json).to be_valid_against_schema('gone')
   end
 end

--- a/spec/presenters/contact_redirect_presenter_spec.rb
+++ b/spec/presenters/contact_redirect_presenter_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
+require 'govuk-content-schema-test-helpers/rspec_matchers'
 
 describe ContactRedirectPresenter do
+  include GovukContentSchemaTestHelpers::RSpecMatchers
+
   let(:contact) { create :contact }
   let(:redirect_to_location) { '/foo/bar/baz' }
   subject(:presenter) { described_class.new(contact, redirect_to_location) }
@@ -28,5 +31,9 @@ describe ContactRedirectPresenter do
 
     expect(content_id).not_to be_blank
     expect(content_id).not_to eq(contact.content_id)
+  end
+
+  it 'is a valid "redirect" item according to the schema' do
+    expect(payload.to_json).to be_valid_against_schema('redirect')
   end
 end

--- a/spec/presenters/contact_redirect_presenter_spec.rb
+++ b/spec/presenters/contact_redirect_presenter_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe ContactRedirectPresenter do
+  let(:contact) { create :contact }
+  let(:redirect_to_location) { '/foo/bar/baz' }
+  subject(:presenter) { described_class.new(contact, redirect_to_location) }
+  let(:payload) { subject.present }
+
+  it "transforms a contact to the redirect format" do
+    expect(payload[:format]).to eq('redirect')
+    expect(payload[:publishing_app]).to eq("contacts")
+    expect(payload[:update_type]).to eq("major")
+    expect(payload[:redirects].size).to eq(1)
+    expect(payload[:base_path]).to eq(contact.link)
+    expect(payload).not_to have_key(:routes)
+  end
+
+  it 'exposes an exact redirect from the contact link to the supplied redirect location' do
+    redirect_payload = payload[:redirects].first
+
+    expect(redirect_payload[:path]).to eq(contact.link)
+    expect(redirect_payload[:type]).to eq('exact')
+    expect(redirect_payload[:destination]).to eq(redirect_to_location)
+  end
+end

--- a/spec/presenters/contact_redirect_presenter_spec.rb
+++ b/spec/presenters/contact_redirect_presenter_spec.rb
@@ -22,4 +22,11 @@ describe ContactRedirectPresenter do
     expect(redirect_payload[:type]).to eq('exact')
     expect(redirect_payload[:destination]).to eq(redirect_to_location)
   end
+
+  it 'includes a content_id that is not the same as contact.content_id' do
+    content_id = payload[:content_id]
+
+    expect(content_id).not_to be_blank
+    expect(content_id).not_to eq(contact.content_id)
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/SAGyyLlH/192-delete-and-redirect-two-hmrc-contact-records

We have to deal with 2 contacts that need to be redirected to somewhere else.  The first still exists and that is what `rake contacts:remove_with_redirect` is for - we remove the contact and publish a new redirect item in the content store to replace it.  The second has already been deleted and that is what `rake contacts:replace_gone_with_redirect` is for - we check that the contact really is "gone" and if so replace that with a redirect item.

These are the only requests we've had so far, so there's no need to make this part of the web UI - although if we ever do, we'd want to support the first form rather than the second.  To that end, the bulk of the implementation of `rake contacts:remove_with_redirect` uses a `DestroyAndRedirectContact` interactor (following the pattern of the existing `DestroyContact` interactor) so it would be easy to plug into the web ui later.  The implementation of `rake contacts:replace_gone_with_redirect` is mostly inline as there should be no need to provide web-ui for this type of workflow if we have a ui for the other workflow.

We also add `content_id` attributes to the "gone" and "redirect" items that we generate for compatibility with the new world.