### PR TITLE
Don't check publishing_app before redirecting

### DIFF
--- a/lib/redirector_for_gone_contact.rb
+++ b/lib/redirector_for_gone_contact.rb
@@ -15,8 +15,6 @@ class RedirectorForGoneContact
       Failure.new(:unpublished_contact, contact.link)
     elsif contact_not_gone?
       Failure.new(:not_gone, contact.link, existing: published_contact)
-    elsif contact_not_published_by_contacts?
-      Failure.new(:not_published_by_contacts, contact.link, existing: published_contact)
     elsif redirect_failed?
       Failure.new(:redirect_failed, contact.link, error: redirect_contact_response)
     else
@@ -36,10 +34,6 @@ class RedirectorForGoneContact
 
   def contact_not_gone?
     published_contact.format != 'gone'
-  end
-
-  def contact_not_published_by_contacts?
-    published_contact.publishing_app != 'contacts'
   end
 
   def redirect_failed?


### PR DESCRIPTION
We were being super cautious and making sure that the publishing_app of a
removed contact was `contacts-admin` and not publishing the redirect if it
wasn't.  However, the representation of a content-item that you get from
the content-store api doesn't include the publishing_app because
content-store provides frontend representations of items and the
publishing_app is really a backend concern.

We're fairly sure this will be ok because we don't let you jsut redirect
any path, it's a constructed path for a contact object and only
contacts-admin would publish those paths.