### PR TITLE
Add contracts tests for content schema

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -51,18 +51,6 @@ class Contact < ActiveRecord::Base
     "/government/organisations/#{organisation.slug}/contact/#{slug}"
   end
 
-  def to_indexed_json
-    {
-      title: title,
-      description: description,
-      link: link,
-      format: "contact",
-      indexable_content: "#{title} #{description} #{contact_groups.map(&:title).join}",
-      organisations: [organisation.slug],
-      public_timestamp: self.updated_at,
-    }
-  end
-
   private
 
   def set_content_id
@@ -71,7 +59,8 @@ class Contact < ActiveRecord::Base
 
   def register_contact
     rummager_id = link.gsub(%r{^/}, '')
-    ::Contacts.rummager_client.add_document("contact", rummager_id, to_indexed_json)
+    rummager_presenter = ContactRummagerPresenter.new(self)
+    ::Contacts.rummager_client.add_document("contact", rummager_id, rummager_presenter.present)
 
     presenter = ContactPresenter.new(self)
     ::Contacts.publishing_api.put_content_item(link, presenter.present)

--- a/app/presenters/contact_groups_presenter.rb
+++ b/app/presenters/contact_groups_presenter.rb
@@ -9,7 +9,7 @@ class ContactGroupsPresenter
     @contact_groups.map do |group|
       {
         title: group.title,
-        organisation: group.organisation.as_json,
+        organisation: ContactOrganisationPresenter.new(group.organisation).present,
         description: govspeak(group.description),
         contacts: group.contacts.map do |contact|
           { description: govspeak(contact.description) }

--- a/app/presenters/contact_organisation_presenter.rb
+++ b/app/presenters/contact_organisation_presenter.rb
@@ -1,0 +1,22 @@
+class ContactOrganisationPresenter
+  attr_reader :organisation
+
+  def initialize(organisation)
+    @organisation = organisation
+  end
+
+  def present
+    {
+      id: organisation.id,
+      title: organisation.title,
+      format: organisation.format,
+      slug: organisation.slug,
+      abbreviation: organisation.abbreviation,
+      govuk_status: organisation.govuk_status,
+      created_at: organisation.created_at,
+      updated_at: organisation.updated_at,
+      ancestry: organisation.ancestry,
+      contact_index_content_id: organisation.contact_index_content_id
+     }
+  end
+end

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -39,7 +39,7 @@ class ContactPresenter
       slug: contact.slug,
       title: contact.title,
       description: contact.description,
-      organisation: contact.organisation.as_json,
+      organisation: ContactOrganisationPresenter.new(contact.organisation).present,
       quick_links: contact.quick_links.map {|q| {title: q.title, url: q.url} },
       query_response_time: (contact.query_response_time or false),
 

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -32,6 +32,7 @@ class ContactPresenter
   def links
     {
       "related" => @contact.related_contacts.pluck(:content_id),
+      "organisations" => Array(@contact.organisation.content_id)
     }
   end
 

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -13,6 +13,7 @@ class ContactPresenter
       title: contact.title,
       description: contact.description,
       format: "contact",
+      locale: "en",
       publishing_app: "contacts",
       rendering_app: "contacts-frontend",
       update_type: "major",

--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -1,0 +1,19 @@
+class ContactRummagerPresenter
+  attr_reader :contact
+
+  def initialize(contact)
+    @contact = contact
+  end
+
+  def present
+    {
+      title: contact.title,
+      description: contact.description,
+      link: contact.link,
+      format: "contact",
+      indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
+      organisations: [contact.organisation.slug],
+      public_timestamp: contact.updated_at,
+    }
+  end
+end

--- a/app/tasks/import_organisations.rb
+++ b/app/tasks/import_organisations.rb
@@ -26,7 +26,8 @@ private
       title: organisation_data.title,
       format: organisation_data.format,
       abbreviation: organisation_data.details.abbreviation,
-      govuk_status: organisation_data.details.govuk_status
+      govuk_status: organisation_data.details.govuk_status,
+      content_id: organisation_data.details.content_id
     }
     organisation.update_attributes!(update_data)
   end

--- a/db/migrate/20151211163428_add_content_id_to_organisations.rb
+++ b/db/migrate/20151211163428_add_content_id_to_organisations.rb
@@ -1,0 +1,9 @@
+class AddContentIdToOrganisations < ActiveRecord::Migration
+  def up
+    add_column :organisations, :content_id, :string
+  end
+
+  def down
+    remove_column :organisations, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150112114153) do
+ActiveRecord::Schema.define(version: 20151211163428) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 20150112114153) do
     t.datetime "updated_at"
     t.string   "ancestry"
     t.string   "contact_index_content_id"
+    t.string   "content_id"
   end
 
   add_index "organisations", ["ancestry"], name: "index_organisations_on_ancestry", using: :btree

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -40,7 +40,9 @@ cd ../..
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 RAILS_ENV=test bundle exec rake ci:setup:rspec
 # TODO as schemas are added for them, change this to include more formats
-RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec spec/presenters/contacts_finder_presenter_spec.rb
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec \
+  spec/presenters/contacts_finder_presenter_spec.rb \
+  spec/presenters/contacts_presenter_spec.rb
 
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"

--- a/spec/features/steps/admin/site_search_steps.rb
+++ b/spec/features/steps/admin/site_search_steps.rb
@@ -4,7 +4,8 @@ module Admin
   module SiteSearchSteps
     def it_should_have_added_the_page_to_search(contact)
       # Check that it's being added as the correct document type
-      expected_json = contact.to_indexed_json.merge(
+      rummager_presenter = ContactRummagerPresenter.new(contact)
+      expected_json = rummager_presenter.present.merge(
         _type: 'contact',
       )
       # export to JSON so that the public_timestamp timestamp is in a string and can

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -11,7 +11,7 @@ describe Contact do
     ContactPresenter.should_receive(:new).with(contact).and_return(presenter)
     ::Contacts.publishing_api.should_receive(:put_content_item).with(contact.link, { some: "JSON" })
 
-    expected_json = JSON.parse(contact.to_indexed_json.to_json)
+    expected_json = JSON.parse(ContactRummagerPresenter.new(contact).present.to_json)
     assert_rummager_posted_item(expected_json)
 
     contact.save
@@ -44,29 +44,6 @@ describe Contact do
         contact.save!
         contact.reload
       }.not_to change { contact.content_id }
-    end
-  end
-
-  describe "to_indexed_json" do
-    it "should generate a Rummager format" do
-      organisation = create(:organisation, slug: 'bowie')
-      contact = create(:contact,
-                        :with_contact_group,
-                        title: "Major Tom",
-                        description: "Back to Earth",
-                        organisation: organisation)
-
-      expected = {
-        title:             "Major Tom",
-        description:       "Back to Earth",
-        link:              "/government/organisations/bowie/contact/major-tom",
-        format:            'contact',
-        indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
-        organisations:     ['bowie'],
-        public_timestamp:  contact.updated_at,
-      }
-
-      expect(contact.to_indexed_json).to eql(expected)
     end
   end
 end

--- a/spec/presenters/contact_groups_presenter_spec.rb
+++ b/spec/presenters/contact_groups_presenter_spec.rb
@@ -7,7 +7,7 @@ describe ContactGroupsPresenter do
     presented = ContactGroupsPresenter.new([group]).present.first
 
     expect(presented[:title]).to eq(group.title)
-    expect(presented[:organisation]).to eq(group.organisation.as_json)
+    expect(presented[:organisation]).to eq(ContactOrganisationPresenter.new(group.organisation).present)
 
     govspeak_description = "<p>#{group.description}</p>"
     expect(presented[:description].strip).to eq(govspeak_description)

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -1,7 +1,13 @@
 require "spec_helper"
+require 'govuk-content-schema-test-helpers/rspec_matchers'
 
 describe ContactPresenter do
   let(:contact) { create :contact }
+
+  it "presents the contact correctly against the schema" do
+    presented = ContactPresenter.new(contact).present
+    expect(presented.to_json).to be_valid_against_schema('contact')
+  end
 
   it "transforms a contact to the correct format" do
     payload = ContactPresenter.new(contact).present
@@ -9,7 +15,6 @@ describe ContactPresenter do
     expect(payload[:content_id]).to eq(contact.content_id)
     expect(payload[:title]).to eq(contact.title)
     expect(payload[:description]).to eq(contact.description)
-    expect(payload[:format]).to eq('contact')
     expect(payload[:publishing_app]).to eq("contacts")
     expect(payload[:rendering_app]).to eq("contacts-frontend")
     expect(payload[:update_type]).to eq("major")

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe ContactRummagerPresenter do
+  it "should generate a Rummager format" do
+    organisation = create(:organisation, slug: 'bowie')
+    contact = create(:contact,
+                      :with_contact_group,
+                      title: "Major Tom",
+                      description: "Back to Earth",
+                      organisation: organisation)
+
+    expected = {
+      title:             "Major Tom",
+      description:       "Back to Earth",
+      link:              "/government/organisations/bowie/contact/major-tom",
+      format:            'contact',
+      indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
+      organisations:     ['bowie'],
+      public_timestamp:  contact.updated_at,
+    }
+
+    expect(ContactRummagerPresenter.new(contact).present).to eql(expected)
+  end
+end


### PR DESCRIPTION
This PR implements contract testing for the newly defined `contact` content schema (https://github.com/alphagov/govuk-content-schemas/pull/167). We follow the 'how-to' docs from govuk-content-schema (https://github.com/alphagov/govuk-content-schemas/blob/master/docs/contract-testing-howto.md)

We move out any code that generates JSON to separate presenters in order to be more consistent with the rest of the app and make more obvious to see which attributes are being exported as JSON.

We also add the contact's organisation `content_id` to the `links` hash so that we can access the organisation in the `content-store`. We do not remove organisation data from the `details` hash yet because in `contacts-frontend` we require the `organisation.abbreviation` attribute, which is currently not stored for `content-store` organisations.