### PR TITLE
Create 'hmrc' organisation only if it does not exist

### DIFF
--- a/app/tasks/seed_database.rb
+++ b/app/tasks/seed_database.rb
@@ -5,7 +5,6 @@ class SeedDatabase
 
   def run
     create_users
-    create_organisation
     create_contact_groups
   end
 
@@ -17,10 +16,6 @@ class SeedDatabase
       u.email = "winston@alphagov.co.uk"
       u.permissions = ["signin"]
     }.save
-  end
-
-  def create_organisation
-    Organisation.create!(slug: "hm-revenue-customs")
   end
 
   CONTACT_GROUPS = [
@@ -102,8 +97,12 @@ class SeedDatabase
         contact_group_type_id: contact_group[:contact_group_type].id,
         title: contact_group[:title],
         description: contact_group[:description],
-        organisation_id: Organisation.find_by(slug: "hm-revenue-customs").id,
+        organisation_id: hmrc_organisation.id
       )
     end
+  end
+
+  def hmrc_organisation
+    Organisation.find_or_create_by(slug: "hm-revenue-customs")
   end
 end


### PR DESCRIPTION
The [README](https://github.com/alphagov/contacts-admin/blob/master/README.md) states to do the following for setting up the local database:
```
bundle exec rake db:schema:load
bundle exec rake db:seed
bundle exec rake contacts:import_hmrc DATA_FILE=db/contact-records.csv
```
This fails with a clean local install, because an organisation with the slug 'hm-revenue-customs' is being created twice (so fails with `ActiveRecord::RecordNotUnique`).
This is because we already import all organisation from Whitehall [here](https://github.com/alphagov/contacts-admin/blob/aaabd12a8ec02be12f18a2604ecd1ac59924bb20/db/seeds.rb#L2) as part of the seed. To fix, we only create it if it does not exist.