### PR TITLE
Fix the govuk-content-schema tests on Jenkins

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -39,10 +39,13 @@ cd ../..
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 RAILS_ENV=test bundle exec rake ci:setup:rspec
+
+RAILS_ENV=test bin/rake db:migrate
+
 # TODO as schemas are added for them, change this to include more formats
 RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec \
   spec/presenters/contacts_finder_presenter_spec.rb \
-  spec/presenters/contacts_presenter_spec.rb
+  spec/presenters/contact_presenter_spec.rb
 
 EXIT_STATUS=$?
 echo "EXIT STATUS: $EXIT_STATUS"


### PR DESCRIPTION
This should fix the Jenkins schema build.

I created a temporary Jenkins job for this branch. The build passed, so I think that should fix it.

https://ci.dev.publishing.service.gov.uk/job/govuk_contacts_admin_schema_tests-TEMPORARY/1/console