### PR TITLE
Make publishing_app value consistent.

### DIFF
--- a/app/presenters/contacts_finder_presenter.rb
+++ b/app/presenters/contacts_finder_presenter.rb
@@ -12,7 +12,7 @@ class ContactsFinderPresenter
       description: description,
       public_updated_at: public_updated_at,
       update_type: "minor",
-      publishing_app: "contacts-admin",
+      publishing_app: "contacts",
       rendering_app: "finder-frontend",
       routes: routes,
       details: details,

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,7 +12,7 @@ namespace :publishing_api do
       content_id: 'b110c03c-3f8d-4327-906b-17ebd872e6a6',
       base_path: '/government/organisations/hm-revenue-customs/contact',
       type: 'exact',
-      publishing_app: 'contacts-admin',
+      publishing_app: 'contacts',
       rendering_app: 'contacts-frontend-old',
     )
   end


### PR DESCRIPTION
This was being sent as "contacts" for the detail pages but "contacts-admin" for the index. (Note that contacts_finder_presenter is not currently used anywhere, but also needs the same value for when it is eventually implemented.)