### PR TITLE
Send the organisation data in the links hash for a contact

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -51,6 +51,10 @@ class Contact < ActiveRecord::Base
     "/government/organisations/#{organisation.slug}/contact/#{slug}"
   end
 
+  def republish
+    register_contact
+  end
+
   private
 
   def set_content_id

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -32,11 +32,10 @@ namespace :contacts do
     end
   end
 
-  desc "Register all contacts with the publishing-api"
-  task :register_in_content_store => :environment do
+  desc "Republish contacts"
+  task :republish => :environment do
     Contact.find_each do |contact|
-      p = ContactPresenter.new(contact)
-      ::Contacts.publishing_api.put_content_item(contact.link, p.present)
+      contact.republish
     end
   end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     format "Non-ministerial department"
     sequence(:abbreviation) { |n| "ORG#{n}" }
     govuk_status "live"
+    content_id { |n| SecureRandom.uuid }
     contact_index_content_id SecureRandom.uuid
   end
 end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -30,6 +30,10 @@ describe ContactPresenter do
     expect(details[:contact_form_links]).to eq(contact.contact_form_links.map(&:as_json))
     expect(details[:more_info_email_address]).to include("<li>")
     expect(details[:more_info_phone_number]).to include("<li>")
+
+    links = payload[:links]
+    expect(links["organisations"].length).to eq(1)
+    expect(links["organisations"].first).to eq(contact.organisation.content_id)
   end
 
   context "with related contacts" do


### PR DESCRIPTION
- Before this change, this app imported organisations from `whitehall` and
  exported this data as part of the `details` hash to the content-store.
  (Organisations are represented in the `content-store` under the format
  of `placeholder_organisation` and only contain a subset of the
  `whitehall` organisation attributes.)
- After this change, the import stays the same, but we can send
  organisation data in the links hash because the frontend will soon
  no longer use `organisation.abbreviation`, which makes it consistent
  with the general patterns for referring to organisations in the new
  world - from the content-store, with just a `content_id`.
- Follows on from 6ec8af.
- Amend the Register rake task into one to Republish contacts, which we'll need to run when we deploy this change and again when we remove organisations from the details hash. We're keeping this in the details hash too for now so that we can do a staged deploy of contacts-admin, contacts-frontend and content-schemas and hopefully have nothing break for users. This will require us to run the Rake task in here twice, once now and once when we deploy an upcoming PR to actually remove the organisations from the details hash, but that's OK.
- Trello:
  https://trello.com/c/lIuKYwFE/235-use-the-full-organisation-name-instead-of-the-abbrevation-to-simplify-the-schemas-and-admin-tool.