### PR TITLE
Make the organisation filter a decent size for the values within it

### DIFF
--- a/app/views/admin/contacts/_search_form.html.erb
+++ b/app/views/admin/contacts/_search_form.html.erb
@@ -4,7 +4,7 @@
                     collection: Organisation.all,
                     label_method: :to_s,
                     value_method: :id,
-                    class: "js-select2 form-control",
+                    class: "js-select2 input-md-5 form-control",
                     data: { placeholder: "Organisation" } %>
   <%= f.input_field :q, placeholder: "Title or description", class: "form-control search-query" %>
   <%= f.submit "Filter contacts", class: "add-left-margin btn btn-default", data: { disable_with: "Working" } %>


### PR DESCRIPTION
- Fixes #169 after just over a year!
- This now stays at a decent size with and without JavaScript on. I
  chose `input-md-5` out of thin air, but most of the org titles now
  display fine in the dropdown, and it's better than it was!

Before:

![screen shot 2016-01-12 at 12 20 06](https://cloud.githubusercontent.com/assets/355033/12263446/13a81dbe-b927-11e5-83ae-f4be6d9fdcc0.png)

After:

![screen shot 2016-01-12 at 12 18 11](https://cloud.githubusercontent.com/assets/355033/12263449/17e860aa-b927-11e5-9e07-3ca7ca22d51f.png)
