### PR TITLE
Publishing API: add organisation link for HMRC index page

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -14,6 +14,9 @@ namespace :publishing_api do
       type: 'exact',
       publishing_app: 'contacts',
       rendering_app: 'contacts-frontend-old',
+      links: {
+        organisations: [Organisation.find_by(title: 'HM Revenue & Customs').content_id],
+      }
     )
   end
 end


### PR DESCRIPTION
This makes the Publishing API payload consistent with all the other
pages within this app.

/cc @issyl0 @jennyd 