### PR TITLE
Remove the organisation data from the `details` hash

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -48,7 +48,6 @@ class ContactPresenter
       slug: contact.slug,
       title: contact.title,
       description: contact.description,
-      organisation: ContactOrganisationPresenter.new(contact.organisation).present,
       quick_links: contact.quick_links.map {|q| {title: q.title, url: q.url} },
       query_response_time: (contact.query_response_time or false),
 

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -31,8 +31,6 @@ describe ContactPresenter do
       expect(payload[:need_ids]).to be_empty
 
       details = payload[:details]
-      expect(details[:slug]).to eq(contact.slug)
-      expect(details[:title]).to eq(contact.title)
       expect(details[:description]).to eq(contact.description)
       expect(details[:quick_links]).to eq(contact.quick_links.map {|q| {title: q.title, url: q.url} })
       expect(details[:contact_form_links]).to eq(contact.contact_form_links.map(&:as_json))


### PR DESCRIPTION
- This needs to be removed as the frontend now picks up `organisation`
  from the links hash, not the details hash (https://github.com/alphagov/contacts-frontend/pull/41). This was only kept in here
  so that we didn't have to faff around changing too much stuff and
  potentially confusing things at deploy-time for #219. This tidies up.

Note: We'll need to run the Republish Contacts Rake task on deploy, so that details no longer have `organisations` in them.

Trello: https://trello.com/c/HEB3ukuP/263-remove-organisations-from-details-hash-for-contacts, related to https://trello.com/c/lIuKYwFE/235-use-the-full-organisation-name-instead-of-the-abbrevation-to-simplify-the-schemas-and-admin-tool.