### PR TITLE
Access remote services via a Services module

### DIFF
--- a/app/interactors/admin/destroy_and_redirect_contact.rb
+++ b/app/interactors/admin/destroy_and_redirect_contact.rb
@@ -14,7 +14,7 @@ module Admin
 
         # Remove from site search
         rummager_id = contact.link.gsub(%r{^/}, '')
-        ::Contacts.rummager_client.delete_document("contact", rummager_id)
+        Services.rummager_client.delete_document("contact", rummager_id)
 
         # Remove from our database
         contact.destroy

--- a/app/interactors/admin/destroy_contact.rb
+++ b/app/interactors/admin/destroy_contact.rb
@@ -12,7 +12,7 @@ module Admin
 
         # Remove from site search
         rummager_id = @contact.link.gsub(%r{^/}, '')
-        ::Contacts.rummager_client.delete_document("contact", rummager_id)
+        Services.rummager_client.delete_document("contact", rummager_id)
 
         # Remove from our database
         @contact.destroy

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -66,7 +66,7 @@ private
   def register_contact
     rummager_id = link.gsub(%r{^/}, '')
     rummager_presenter = ContactRummagerPresenter.new(self)
-    ::Contacts.rummager_client.add_document("contact", rummager_id, rummager_presenter.present)
+    Services.rummager_client.add_document("contact", rummager_id, rummager_presenter.present)
 
     presenter = ContactPresenter.new(self)
     Publisher.publish(presenter)

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -13,7 +13,7 @@ class WorldLocation
 
   def self.all
     cache_fetch("all") do
-      Contacts.worldwide_api.world_locations.with_subsequent_pages
+      Services.worldwide_api.world_locations.with_subsequent_pages
         .map { |l| new(l) if l.format == "World location" && l.details && l.details.slug.present? }
         .compact
     end
@@ -21,7 +21,7 @@ class WorldLocation
 
   def self.find(location_slug)
     cache_fetch("find_#{location_slug}") do
-      data = Contacts.worldwide_api.world_location(location_slug)
+      data = Services.worldwide_api.world_location(location_slug)
       new(data) if data
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,10 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
-require 'gds_api/worldwide'
-require 'gds_api/organisations'
-require 'gds_api/rummager'
-require 'gds_api/publishing_api_v2'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -18,6 +14,7 @@ module Contacts
 
     config.autoload_paths += %W(
       #{config.root}/app/models/website
+      #{config.root}/lib/
     )
 
     config.assets.precompile += %w(
@@ -40,17 +37,6 @@ module Contacts
       g.template_engine     :erb
       g.test_framework      :rspec, fixture: false
       g.fixture_replacement :factory_girl, dir: 'spec/factories'
-    end
-
-    config.after_initialize do
-      Contacts.worldwide_api = GdsApi::Worldwide.new( Plek.current.find('whitehall-admin') )
-
-      Contacts.rummager_client = GdsApi::Rummager.new(Plek.current.find('search'))
-
-      ::Contacts.publishing_api = GdsApi::PublishingApiV2.new(
-        Plek.current.find('publishing-api'),
-        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-      )
     end
   end
 end

--- a/lib/publisher.rb
+++ b/lib/publisher.rb
@@ -19,7 +19,7 @@ class Publisher
   end
 
   def self.client
-    ::Contacts.publishing_api
+    Services.publishing_api
   end
 
 private

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,20 @@
+require 'gds_api/worldwide'
+require 'gds_api/rummager'
+require 'gds_api/publishing_api_v2'
+
+module Services
+  def self.worldwide_api
+    @worldwide_api ||= GdsApi::Worldwide.new(Plek.current.find('whitehall-admin'))
+  end
+
+  def self.rummager_client
+    @rummager_client ||= GdsApi::Rummager.new(Plek.current.find('search'))
+  end
+
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.current.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -7,7 +7,7 @@ namespace :publishing_api do
   task publish_special_routes: :environment do
     special_route_publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
       logger: Logger.new(STDOUT),
-      publishing_api: Contacts.publishing_api
+      publishing_api: Services.publishing_api
     )
     special_route_publisher.publish(
       title: 'HMRC contacts finder',

--- a/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
+++ b/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
@@ -7,7 +7,7 @@ describe Admin::DestroyAndRedirectContact do
     subject!(:interactor) { described_class.new(contact, redirect_to_location) }
 
     it 'removes the item from rummager' do
-      ::Contacts.rummager_client.
+      Services.rummager_client.
         should_receive(:delete_document).
         with("contact", contact.link.gsub(%r{^/}, ''))
 


### PR DESCRIPTION
This is a convention that's prevalent across several other GOVUK apps,
particularly those that have been migrated to the new tagging
architecture and the V2 publishing API (see collections-publisher and
policy-publisher, for example).