### PR TITLE
Upgrades gds-api-adapters to 28.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "virtus", "~> 1.0.0.beta8"
 gem "paper_trail", ">= 3.0.0.beta1"
 gem "govspeak", "1.2.3"
 gem "gds-sso", "~> 9.3.0"
-gem "gds-api-adapters", '26.7.0'
+gem "gds-api-adapters", '28.1.0'
 gem "lrucache", "0.1.4"
 gem "plek", ">= 1.0.0"
 gem 'govuk_admin_template', '3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    domain_name (0.5.24)
+    domain_name (0.5.20160128)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.9)
     erubis (2.7.0)
@@ -99,11 +99,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.7.0)
+    gds-api-adapters (28.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (9.3.0)
@@ -162,7 +162,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.3.15)
     named (1.1.0)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.5.11)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -187,7 +187,7 @@ GEM
       activesupport (>= 3.0, < 5.0)
     parser (2.3.0.1)
       ast (~> 2.2)
-    plek (1.10.0)
+    plek (1.12.0)
     powerpack (0.1.1)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -200,7 +200,7 @@ GEM
     rack (1.5.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -310,7 +310,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -348,7 +348,7 @@ DEPENDENCIES
   factory_girl_rails
   fakefs
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.7.0)
+  gds-api-adapters (= 28.1.0)
   gds-sso (~> 9.3.0)
   govspeak (= 1.2.3)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/spec/features/admin/contact_edit_spec.rb
+++ b/spec/features/admin/contact_edit_spec.rb
@@ -36,7 +36,7 @@ describe "Contact editing", auth: :user do
                    description: "new description"
                   )
 
-    assert_publishing_api_put_content(contact.content_id, title: "new title", description: "new description")
+    assert_publishing_api_put_content(contact.content_id, request_json_includes(title: "new title", description: "new description"))
   end
 
   specify "updating a contact sends the data to Rummager" do

--- a/spec/features/steps/admin/publishing_api_steps.rb
+++ b/spec/features/steps/admin/publishing_api_steps.rb
@@ -1,6 +1,15 @@
 module Admin
   module PublishingApiSteps
-    def gone_item_for(_gone_uuid, contact)
+    def it_should_have_archived_the_page(gone_uuid, contact)
+      assert_publishing_api_put_content(
+        gone_uuid,
+        request_json_includes(contact_content(contact))
+      )
+    end
+
+  private
+
+    def contact_content(contact)
       {
         "format" => "gone",
         "publishing_app" => "contacts",
@@ -12,10 +21,6 @@ module Admin
           }
         ]
       }
-    end
-
-    def it_should_have_archived_the_page(gone_uuid, contact)
-      assert_publishing_api_put_content(gone_uuid, gone_item_for(gone_uuid, contact))
     end
   end
 end

--- a/spec/interactors/admin/destroy_contact_spec.rb
+++ b/spec/interactors/admin/destroy_contact_spec.rb
@@ -16,7 +16,7 @@ describe Admin::DestroyContact do
       end
 
       it "should replace the item in content store with a gone item" do
-        presenter = double("ContactGonePresenter", present: { some: "JSON" })
+        presenter = double(ContactGonePresenter, present: { some: "JSON" })
         ContactGonePresenter.should_receive(:new).with(contact).and_return(presenter)
         expect(Publisher).to receive(:publish).with(presenter)
 


### PR DESCRIPTION
When gds-api-adapters was bumped to version 27.0.0 (https://github.com/alphagov/gds-api-adapters/pull/417) it included changes to the test helpers of Publishing API V2 (https://github.com/alphagov/gds-api-adapters/pull/416), those changes broken 3 specs, reading @gpeng fixes (https://github.com/alphagov/whitehall/pull/2429/files#diff-69c5d68679b4279731fb962947d0bd31R148) I noticed that we now need to include a new method `request_json_includes` when `assert_publishing_api_put_content`.

After fixing this we are now able to upgrade to the current `gds-api-adapter`.