### PR TITLE
[WIP] Move contact after_save callback to service objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 group :development, :test do
   gem "pry-rails"
+  gem 'pry-nav'
 end
 
 # testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     quiet_assets (1.1.0)
@@ -361,6 +363,7 @@ DEPENDENCIES
   mysql2 (~> 0.3.13)
   paper_trail (>= 3.0.0.beta1)
   plek (>= 1.0.0)
+  pry-nav
   pry-rails
   quiet_assets (= 1.1.0)
   railroady

--- a/app/commands/rummager.rb
+++ b/app/commands/rummager.rb
@@ -1,0 +1,13 @@
+module Commands
+  class Rummager
+    def initialize(contact)
+      @contact = contact
+    end
+
+    def call
+      rummager_id        = @contact.link.sub(%r{^/}, '')
+      rummager_presenter = ContactRummagerPresenter.new(@contact)
+      Services.rummager_client.add_document("contact", rummager_id, rummager_presenter.present)
+    end
+  end
+end

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -1,5 +1,3 @@
-require './app/commands/rummager.rb'
-
 class Admin::ContactsController < AdminController
   before_filter :load_contact, only: [:edit, :update, :clone, :destroy]
   helper_method :search
@@ -14,6 +12,7 @@ class Admin::ContactsController < AdminController
 
   def update
     if @contact.update_attributes(contact_params)
+      register_contact
       redirect_to successful_update_url, notice: "Contact successfully updated"
     else
       render :edit
@@ -29,7 +28,7 @@ class Admin::ContactsController < AdminController
   def create
     @contact = Contact.new(contact_params)
     if @contact.save
-      Commands::Rummager.new(@contact).call
+      register_contact
       redirect_to admin_contacts_path, notice: "Contact successfully created"
     else
       render :new
@@ -46,6 +45,11 @@ class Admin::ContactsController < AdminController
   end
 
 private
+
+  def register_contact
+    Admin::ContactPublisher.new(@contact).call
+    Admin::Rummager.new(@contact).call
+  end
 
   def successful_update_url
     if params[:tab].present?

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -1,3 +1,5 @@
+require './app/commands/rummager.rb'
+
 class Admin::ContactsController < AdminController
   before_filter :load_contact, only: [:edit, :update, :clone, :destroy]
   helper_method :search
@@ -27,6 +29,7 @@ class Admin::ContactsController < AdminController
   def create
     @contact = Contact.new(contact_params)
     if @contact.save
+      Commands::Rummager.new(@contact).call
       redirect_to admin_contacts_path, notice: "Contact successfully created"
     else
       render :new

--- a/app/interactors/admin/contact_publisher.rb
+++ b/app/interactors/admin/contact_publisher.rb
@@ -1,0 +1,12 @@
+module Admin
+  class ContactPublisher
+    def initialize(contact)
+      @contact = contact
+    end
+
+    def call
+      presenter = ContactPresenter.new(@contact)
+      Publisher.publish(presenter)
+    end
+  end
+end

--- a/app/interactors/admin/rummager.rb
+++ b/app/interactors/admin/rummager.rb
@@ -1,4 +1,4 @@
-module Commands
+module Admin
   class Rummager
     def initialize(contact)
       @contact = contact

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -64,10 +64,6 @@ private
   end
 
   def register_contact
-    rummager_id = link.gsub(%r{^/}, '')
-    rummager_presenter = ContactRummagerPresenter.new(self)
-    Services.rummager_client.add_document("contact", rummager_id, rummager_presenter.present)
-
     presenter = ContactPresenter.new(self)
     Publisher.publish(presenter)
   end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,8 +7,6 @@ class Contact < ActiveRecord::Base
   before_validation :set_content_id, on: :create
   attr_readonly :content_id
 
-  after_save :register_contact
-
   friendly_id :title, use: :history
 
   belongs_to :organisation
@@ -61,10 +59,5 @@ private
 
   def set_content_id
     self.content_id ||= SecureRandom.uuid
-  end
-
-  def register_contact
-    presenter = ContactPresenter.new(self)
-    Publisher.publish(presenter)
   end
 end

--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -13,7 +13,7 @@ class ContactRummagerPresenter
       format: "contact",
       indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
       organisations: [contact.organisation.slug],
-      public_timestamp: contact.updated_at,
+      public_timestamp: contact.updated_at.iso8601,
     }
   end
 end

--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -24,10 +24,26 @@ describe "Contact creation", auth: :user do
     }.to change { Contact.count }.by(1)
   end
 
-  context 'when contact is created' do
-    it "should be sent to rummager after being created" do
+  context "when contact is created" do
+    it "delegates to Commands::Rummager" do
       rummager_double = double call: true
-      expect(Commands::Rummager).to receive(:new).with(kind_of(Contact)).and_return(rummager_double)
+      expect(Admin::Rummager).to receive(:new).with(kind_of(Contact)).and_return(rummager_double)
+
+      create_contact(
+        title: contact.title,
+        description: contact.description,
+        contact_information: contact.contact_information
+      ) do
+        select contact_organisation, from: "contact_organisation_id"
+        select contact_group, from: "contact_contact_group_ids"
+      end
+    end
+
+    it "delegates to Commands::ContactPublisher" do
+      publisher_double = double call: true
+
+      expect(Admin::ContactPublisher).to receive(:new)
+        .with(kind_of(Contact)).and_return(publisher_double)
 
       create_contact(
         title: contact.title,

--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -23,4 +23,20 @@ describe "Contact creation", auth: :user do
       end
     }.to change { Contact.count }.by(1)
   end
+
+  context 'when contact is created' do
+    it "should be sent to rummager after being created" do
+      rummager_double = double call: true
+      expect(Commands::Rummager).to receive(:new).with(kind_of(Contact)).and_return(rummager_double)
+
+      create_contact(
+        title: contact.title,
+        description: contact.description,
+        contact_information: contact.contact_information
+      ) do
+        select contact_organisation, from: "contact_organisation_id"
+        select contact_group, from: "contact_contact_group_ids"
+      end
+    end
+  end
 end

--- a/spec/features/admin/contact_edit_spec.rb
+++ b/spec/features/admin/contact_edit_spec.rb
@@ -47,7 +47,7 @@ describe "Contact editing", auth: :user do
                    description: "newer description"
                   )
 
-    it_should_have_added_the_page_to_search(contact)
+    it_should_have_added_the_page_to_search(contact.reload)
   end
 
   specify "updating more info fields from tabs redirects the user back to the tab" do

--- a/spec/features/steps/admin/site_search_steps.rb
+++ b/spec/features/steps/admin/site_search_steps.rb
@@ -3,13 +3,12 @@ require 'gds_api/test_helpers/json_client_helper'
 module Admin
   module SiteSearchSteps
     def it_should_have_added_the_page_to_search(contact)
-      # Check that it's being added as the correct document type
+      # Checks that it's being added as the correct document type
       rummager_presenter = ContactRummagerPresenter.new(contact)
-      expected_json = rummager_presenter.present.merge(
-        _type: 'contact',
-      )
-      # export to JSON so that the public_timestamp timestamp is in a string and can
-      # be compared to the JSON captured by Webmock
+      expected_json = rummager_presenter.present.merge(_type: 'contact')
+
+      # exports to JSON so that the public_timestamp timestamp
+      # is in a string and can be compared to the JSON captured by Webmock
       expected_json = JSON.parse(expected_json.to_json)
       assert_rummager_posted_item(expected_json)
     end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -4,16 +4,6 @@ describe Contact do
   it { should validate_presence_of :title }
   it { should validate_presence_of :description }
 
-  it "should be registered after saving" do
-    contact = build(:contact)
-    presenter = ContactPresenter.new(contact)
-
-    ContactPresenter.should_receive(:new).with(contact).and_return(presenter)
-    Publisher.should_receive(:publish).with(presenter)
-
-    contact.save
-  end
-
   context "content ID" do
     it "should be set on a new contact" do
       contact = build(:contact)

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -14,13 +14,6 @@ describe Contact do
     contact.save
   end
 
-  it "should be in rummager after being created" do
-    contact = create(:contact)
-
-    expected_json = JSON.parse(ContactRummagerPresenter.new(contact).present.to_json)
-    assert_rummager_posted_item(expected_json)
-  end
-
   context "content ID" do
     it "should be set on a new contact" do
       contact = build(:contact)

--- a/spec/models/post_address_spec.rb
+++ b/spec/models/post_address_spec.rb
@@ -1,7 +1,16 @@
 require "spec_helper"
+require 'gds_api/test_helpers/worldwide'
 
 describe PostAddress do
-  let(:item) { create(:post_address) }
+  include GdsApi::TestHelpers::Worldwide
+
+  let(:item) { build(:post_address) }
+
+  before do
+    worldwide_api_has_location(item.world_location_slug)
+    item.save
+  end
+
   it_behaves_like "an associated data model"
 
   it { should validate_presence_of :contact }

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -16,7 +16,7 @@ describe ContactRummagerPresenter do
       format:            'contact',
       indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
       organisations:     ['bowie'],
-      public_timestamp:  contact.updated_at,
+      public_timestamp:  contact.updated_at.iso8601,
     }
 
     expect(ContactRummagerPresenter.new(contact).present).to eql(expected)

--- a/spec/presenters/post_addresses_presenter_spec.rb
+++ b/spec/presenters/post_addresses_presenter_spec.rb
@@ -3,10 +3,11 @@ require 'gds_api/test_helpers/worldwide'
 
 describe PostAddressesPresenter do
   include GdsApi::TestHelpers::Worldwide
-  let(:post) { create :post_address, description: "post description" }
+  let(:post) { build :post_address, description: "post description" }
 
   it "transforms a contact to the correct format" do
     worldwide_api_has_location(post.world_location_slug)
+    post.save
 
     presented = PostAddressesPresenter.new([post]).present.first
 


### PR DESCRIPTION
Before merging, please note that this branch was built 
on top of the same branch in this Pull Request: https://github.com/alphagov/contacts-admin/pull/229

This callback made the Contact model hard to modify, it was doing too many
things during save:

- It was being wrapped in a presenter to be prepared to be sent to
Rummager
- It was being wrapped in a presenter to be sent to Publishing API

This was proved to be a bottleneck when we tried our first attempt in
migrating contact-admin to tag organisations from Publishing API.

The callback is now replaced with two different classes responsible only
for sending data to both Rummager and Publishing API and both happen in the
controller after `update` and `save`.

This is a pre-work related with:
https://trello.com/c/afa0Mfa4/446-migrate-contacts-admin-to-new-tagging-infrastructure