### PR TITLE
Send organisations link at creation

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -25,10 +25,11 @@ class Admin::ContactsController < AdminController
   end
 
   def create
-    @contact = Contact.new(contact_params)
-    if @contact.save
+    contact_creator = Admin::CreateContact.new(contact_params)
+    if contact_creator.save
       redirect_to admin_contacts_path, notice: "Contact successfully created"
     else
+      @contact = contact_creator.contact
       render :new
     end
   end

--- a/app/interactors/admin/clone_contact.rb
+++ b/app/interactors/admin/clone_contact.rb
@@ -5,6 +5,14 @@ module Admin
     end
 
     def clone
+      clone = create_record
+      send_links_to_publishing_api(clone)
+      clone
+    end
+
+  private
+
+    def create_record
       clone = @contact.dup
       clone.save
 
@@ -40,6 +48,13 @@ module Admin
       Contact.reset_counters(clone.id, :email_addresses)
       Contact.reset_counters(clone.id, :post_addresses)
       clone
+    end
+
+    def send_links_to_publishing_api(clone)
+      Publisher.client.put_links(
+        clone.content_id,
+        links: { organisations: [clone.organisation.content_id] }
+      )
     end
   end
 end

--- a/app/interactors/admin/create_contact.rb
+++ b/app/interactors/admin/create_contact.rb
@@ -1,0 +1,26 @@
+module Admin
+  class CreateContact
+    def initialize(params)
+      @params = params
+    end
+
+    def contact
+      @contact ||= Contact.new(@params)
+    end
+
+    def save
+      return false unless contact.save
+      send_links_to_publishing_api
+      true
+    end
+
+  private
+
+    def send_links_to_publishing_api
+      Publisher.client.put_links(
+        contact.content_id,
+        links: { organisations: [contact.organisation.content_id] }
+      )
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -28,6 +28,8 @@ class Contact < ActiveRecord::Base
   validates :description, presence: true
   validates :content_id, uuid: true
 
+  validate :organisation_should_never_change
+
   scope :by_title, -> { order("title ASC") }
   scope :ungrouped, -> { where(contact_group_id: nil) }
   scope :for_listing, -> {
@@ -70,5 +72,11 @@ private
 
     presenter = ContactPresenter.new(self)
     Publisher.publish(presenter)
+  end
+
+  def organisation_should_never_change
+    if persisted? && organisation_id_changed?
+      errors[:organisation] << "can't be changed"
+    end
   end
 end

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -34,7 +34,6 @@ class ContactPresenter
     {
       links: {
         "related" => @contact.related_contacts.pluck(:content_id),
-        "organisations" => Array(@contact.organisation.content_id)
       }
     }
   end

--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -2,7 +2,11 @@
   <%= simple_form_for [:admin, contact] do |f| %>
     <fieldset>
       <%= f.input :title, input_html: { class: 'input-md-4 form-control' } %>
-      <%= f.input :organisation_id, label: "Organisation", collection: Organisation.all, label_method: :to_s, value_method: :id, include_blank: false, input_html: { class: 'input-md-3 form-control js-select2' } %>
+
+      <% unless contact.persisted? %>
+        <%= f.input :organisation_id, label: "Organisation", collection: Organisation.all, label_method: :to_s, value_method: :id, include_blank: false, input_html: { class: 'input-md-3 form-control js-select2' } %>
+      <% end %>
+
       <%= f.association :contact_groups, collection: ContactGroup.all, multiple: true, input_html: { class: 'input-md-8 form-control js-select2' } %>
       <%= f.input :description, as: :text, input_html: { rows: 8, class: 'input-md-8 form-control' } %>
       <%= f.input :before_you_contact_us, as: :text, label: 'Before you contact us', input_html: { rows: 5, class: 'input-md-8 form-control' }, hint: formatting_help_link %>

--- a/spec/features/admin/contact_clone_spec.rb
+++ b/spec/features/admin/contact_clone_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "Contact cloning", auth: :user do
+  specify "it can be cloned" do
+    contact = create(:contact)
+    visit edit_admin_contact_path(contact)
+
+    expect {
+      click_on 'Clone'
+    }.to change { Contact.count }.by(1)
+
+    cloned_contact = Contact.last
+
+    assert_publishing_api_put_links(
+      cloned_contact.content_id,
+      { links: { organisations: [cloned_contact.organisation.content_id] } }
+    )
+  end
+end

--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -4,7 +4,7 @@ describe "Contact creation", auth: :user do
   include Admin::ContactSteps
 
   let!(:contact_group)       { create(:contact_group, :with_organisation, title: "new contact type") }
-  let(:contact)              { build :contact }
+  let(:contact)              { attributes_for :contact }
   let!(:contact_organisation) { create :organisation }
 
   before {
@@ -14,9 +14,9 @@ describe "Contact creation", auth: :user do
   specify "it can be created" do
     expect {
       create_contact(
-        title: contact.title,
-        description: contact.description,
-        contact_information: contact.contact_information
+        title: contact[:title],
+        description: contact[:description],
+        contact_information: contact[:contact_information]
       ) do
         select contact_organisation, from: "contact_organisation_id"
         select contact_group, from: "contact_contact_group_ids"

--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -23,4 +23,20 @@ describe "Contact creation", auth: :user do
       end
     }.to change { Contact.count }.by(1)
   end
+
+  specify "it tags the content item with the correct organisation" do
+    create_contact(
+      title: contact[:title],
+      description: contact[:description],
+    ) do
+      select contact_organisation, from: "contact_organisation_id"
+    end
+
+    created_contact = Contact.last
+
+    assert_publishing_api_put_links(
+      created_contact.content_id,
+      { links: { organisations: [contact_organisation.content_id] } }
+    )
+  end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -49,4 +49,28 @@ describe Contact do
       }.not_to change { contact.content_id }
     end
   end
+
+  describe '#organisation' do
+    it "can be set on create" do
+      contact = create(:contact, organisation: create(:organisation))
+
+      expect(contact).to be_valid
+    end
+
+    it "can not be changed" do
+      contact = create(:contact)
+
+      contact.organisation = create(:organisation)
+
+      expect(contact).not_to be_valid
+    end
+
+    it "can not be changed via `organisation_id`" do
+      contact = create(:contact)
+
+      contact.organisation_id = 1212
+
+      expect(contact).not_to be_valid
+    end
+  end
 end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -46,10 +46,12 @@ describe ContactPresenter do
     end
 
     it "returns links data" do
+      content_id = SecureRandom.uuid
+      contact.related_contacts << create(:contact, content_id: content_id)
+
       links = ContactPresenter.new(contact).links
 
-      expect(links[:links]["organisations"].length).to eq(1)
-      expect(links[:links]["organisations"].first).to eq(contact.organisation.content_id)
+      expect(links[:links]["related"]).to eq([content_id])
     end
   end
 


### PR DESCRIPTION
Finding Things is "migrating" the [tagging for all applications](https://trello.com/c/A4P3V9gK). Migration means that publisher apps should read & write the links hash from the publishing-api. This allows pages to be tagged by multiple apps. For example, a Whitehall document will be taggable in Whitehall, content-tagger and (in the future) a bulk-tagger application. Instead of the publisher apps having knowledge of the tags in their database, we have it centrally stored in the publishing-api.

Specifically for this application, it means that we should read & write the `organisations` links field from the publishing-api.

Originally, we wanted to refactor this app so that the organisation-dropdown for Contact is populated from the publishing-api and not saved in the database (#230). This proved very difficult because the Contact model uses the organisation to determine its base path, among other things.

The solution we have come up with is this:

- Users can only select the organisation for the contact on creation
- After creation, we send the organisation to the publishing-api _once_

This means that if the `organisations` in the links is modified, contacts-admin will not accidentally overwrite it - and we can start tagging contact pages with content-tagger. We don't really change the current behaviour, as organisations don't get edited anyway (everything is HMRC).

Trello: https://trello.com/c/afa0Mfa4

Paired with @Davidslv