### PR TITLE
Don't send update_type in content payload

### DIFF
--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -13,7 +13,6 @@ class ContactGonePresenter
     {
       format: "gone",
       publishing_app: "contacts",
-      update_type: "major",
       base_path: contact.link,
       routes: [
         { path: contact.link, type: "exact" }

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -19,7 +19,6 @@ class ContactPresenter
       locale: "en",
       publishing_app: "contacts",
       rendering_app: "contacts-frontend",
-      update_type: "major",
       base_path: contact.link,
       public_updated_at: contact.updated_at,
       routes: [

--- a/app/presenters/contact_redirect_presenter.rb
+++ b/app/presenters/contact_redirect_presenter.rb
@@ -12,7 +12,6 @@ class ContactRedirectPresenter
     {
       format: "redirect",
       publishing_app: "contacts",
-      update_type: "major",
       base_path: contact.link,
       redirects: [
         {

--- a/lib/publisher.rb
+++ b/lib/publisher.rb
@@ -35,7 +35,7 @@ private
 
   def publish_item
     Publisher.client.publish(presenter.content_id,
-                             presenter.payload[:update_type],
+                            "major",
                              locale: presenter.payload[:locale])
   end
 end

--- a/spec/features/steps/admin/publishing_api_steps.rb
+++ b/spec/features/steps/admin/publishing_api_steps.rb
@@ -13,7 +13,6 @@ module Admin
       {
         "format" => "gone",
         "publishing_app" => "contacts",
-        "update_type" => "major",
         "routes" => [
           {
             "path" =>  contact.link,

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -28,7 +28,7 @@ describe Publisher do
       it 'calls publish' do
         Publisher.client.should_receive(:publish)
           .with(contact.content_id,
-                presenter.payload[:update_type],
+                "major",
                 locale: presenter.payload[:locale])
 
         Publisher.new(presenter).publish

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -11,7 +11,6 @@ describe ContactGonePresenter do
   it "transforms a contact to the correct format" do
     expect(payload[:format]).to eq('gone')
     expect(payload[:publishing_app]).to eq("contacts")
-    expect(payload[:update_type]).to eq("major")
     expect(payload[:routes].first[:path]).to eq(contact.link)
     expect(payload[:base_path]).to eq(contact.link)
   end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -25,7 +25,6 @@ describe ContactPresenter do
       expect(payload[:description]).to eq(contact.description)
       expect(payload[:publishing_app]).to eq("contacts")
       expect(payload[:rendering_app]).to eq("contacts-frontend")
-      expect(payload[:update_type]).to eq("major")
       expect(payload[:routes].first[:path]).to eq(contact.link)
       expect(payload[:public_updated_at]).to be_present
       expect(payload[:need_ids]).to be_empty

--- a/spec/presenters/contact_redirect_presenter_spec.rb
+++ b/spec/presenters/contact_redirect_presenter_spec.rb
@@ -12,7 +12,6 @@ describe ContactRedirectPresenter do
   it "transforms a contact to the redirect format" do
     expect(payload[:format]).to eq('redirect')
     expect(payload[:publishing_app]).to eq("contacts")
-    expect(payload[:update_type]).to eq("major")
     expect(payload[:redirects].size).to eq(1)
     expect(payload[:base_path]).to eq(contact.link)
     expect(payload).not_to have_key(:routes)


### PR DESCRIPTION
`update_type` is supposed to be sent as an argument to the `publish` action.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/259 