### PR TITLE
Migration to remove an org created in error

### DIFF
--- a/db/migrate/20160420132844_remove_appointed_person_for_england_and_wales_organisation.rb
+++ b/db/migrate/20160420132844_remove_appointed_person_for_england_and_wales_organisation.rb
@@ -1,0 +1,17 @@
+class RemoveAppointedPersonForEnglandAndWalesOrganisation < ActiveRecord::Migration
+  def up
+    organisation = Organisation.find_by_slug('appointed-person-for-england-and-wales-under-the-proceeds-of-crime-act-2002')
+    if organisation.present?
+      # These would need extra redirects or deciding what to do with if there
+      # were any
+      raise "Unexpected contacts for #{organisation.title}" if organisation.contacts.count > 0
+
+      organisation.contact_groups.destroy_all
+      organisation.destroy
+    end
+  end
+
+  def down
+    # This org was created in error, there's no need for a down to re-instate it
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151211163428) do
+ActiveRecord::Schema.define(version: 20160420132844) do
 
   create_table "contact_groups", force: true do |t|
     t.integer  "contact_group_type_id"


### PR DESCRIPTION
This org was created in error and we are removing it.  The traffic is very low so we're not issuing a 410, just removing it (it should never have existed so a 404 is really what we want).

This is PR 4 of 5 for removing this org.

For more detail: https://trello.com/c/jbImjyLP/359-delete-an-org-page-5
