### PR TITLE
Remove invalid breadcrumbs aria role

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
 <body class="hmrc-contacts-body">
 <% unless local_assigns[:show_breadcrumbs] %>
 <div id="global-breadcrumb" class="header-context group">
-  <ol role="breadcrumbs" class="group">
+  <ol class="group">
     <li>
       <%= link_to "Home", '/' %>
     </li>


### PR DESCRIPTION
`role="breadcrumbs"` is not a thing.
https://www.w3.org/TR/wai-aria/roles#role_definitions

We previously removed from the component:
https://github.com/alphagov/static/pull/737