### PR TITLE
WIP - RFC - Update links payloads for Pub API and Rummager

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -33,6 +33,7 @@ class ContactPresenter
     {
       links: {
         "related" => @contact.related_contacts.pluck(:content_id),
+        "organisations" => [@contact.organisation.content_id],
       }
     }
   end

--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -12,7 +12,6 @@ class ContactRummagerPresenter
       link: contact.link,
       format: "contact",
       indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
-      organisations: [contact.organisation.slug],
       public_timestamp: contact.updated_at,
     }
   end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -42,6 +42,8 @@ describe ContactPresenter do
     it "presents the contact correctly against the schema" do
       links = ContactPresenter.new(contact).links
       expect(links.to_json).to be_valid_against_links_schema("contact")
+
+      expect(links[:links]["organisations"]).to eq([contact.organisation.content_id])
     end
 
     it "returns links data" do

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -2,20 +2,16 @@ require "spec_helper"
 
 describe ContactRummagerPresenter do
   it "should generate a Rummager format" do
-    organisation = create(:organisation, slug: 'bowie')
     contact = create(:contact,
                       :with_contact_group,
                       title: "Major Tom",
-                      description: "Back to Earth",
-                      organisation: organisation)
-
+                      description: "Back to Earth")
     expected = {
       title:             "Major Tom",
       description:       "Back to Earth",
-      link:              "/government/organisations/bowie/contact/major-tom",
+      link:              "/government/organisations/#{contact.organisation.slug}/contact/major-tom",
       format:            'contact',
       indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
-      organisations:     ['bowie'],
       public_timestamp:  contact.updated_at,
     }
 


### PR DESCRIPTION
This work started with the idea of removing organisations from the payload sent to rummager given that links data now will be fetched from the Publishing API.
I found out that we're not actually sending organisations data to the Publishing API. I am thinking about splitting this work into two PR so that it'll be easier to deploy. 

I'd assume we will need to republish all the contacts' organisations to the Pub API, then in a later piece of work stop sending contacts' organisation data to Rummager.

Thoughts? 

cc: @mobaig  @tijmenb 

Ticket:
https://trello.com/c/LbZA0i15/678-stop-apps-from-sending-mainstream-browse-pages-topics-and-organisations-to-rummager