### PR TITLE
Remove organisation link from Rummager payload

### DIFF
--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -12,7 +12,6 @@ class ContactRummagerPresenter
       link: contact.link,
       format: "contact",
       indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
-      organisations: [contact.organisation.slug],
       public_timestamp: contact.updated_at,
     }
   end

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -2,20 +2,16 @@ require "spec_helper"
 
 describe ContactRummagerPresenter do
   it "should generate a Rummager format" do
-    organisation = create(:organisation, slug: 'bowie')
     contact = create(:contact,
                       :with_contact_group,
                       title: "Major Tom",
-                      description: "Back to Earth",
-                      organisation: organisation)
-
+                      description: "Back to Earth")
     expected = {
       title:             "Major Tom",
       description:       "Back to Earth",
-      link:              "/government/organisations/bowie/contact/major-tom",
+      link:              "/government/organisations/#{contact.organisation.slug}/contact/major-tom",
       format:            'contact',
       indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
-      organisations:     ['bowie'],
       public_timestamp:  contact.updated_at,
     }
 


### PR DESCRIPTION
Blocked by:
https://github.com/alphagov/contacts-admin/pull/240
The work in the PR above needs to be deployed, after that the task to republish all contacts should be run (`rake contacts:republish`).

Why?:

Rummager has recently been updated to fetch links data directly from the
publishing API when indexing a document. Setting Rummager links data in
the publishing app is therefore redundant.

Ticket: https://trello.com/c/A4P3V9gK/414-mission-new-simplified-tagging-architecture