### PR TITLE
Use `document_type` and `schema_name`

### DIFF
--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -11,7 +11,8 @@ class ContactGonePresenter
 
   def present
     {
-      format: "gone",
+      document_type: "gone",
+      schema_name: "gone",
       publishing_app: "contacts",
       base_path: contact.link,
       routes: [

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -15,7 +15,8 @@ class ContactPresenter
     {
       title: contact.title,
       description: contact.description,
-      format: "contact",
+      document_type: "contact",
+      schema_name: "contact",
       locale: "en",
       publishing_app: "contacts",
       rendering_app: "contacts-frontend",

--- a/app/presenters/contact_redirect_presenter.rb
+++ b/app/presenters/contact_redirect_presenter.rb
@@ -10,7 +10,8 @@ class ContactRedirectPresenter
 
   def present
     {
-      format: "redirect",
+      document_type: "redirect",
+      schema_name: "redirect",
       publishing_app: "contacts",
       base_path: contact.link,
       redirects: [

--- a/spec/features/steps/admin/publishing_api_steps.rb
+++ b/spec/features/steps/admin/publishing_api_steps.rb
@@ -11,7 +11,8 @@ module Admin
 
     def contact_content(contact)
       {
-        "format" => "gone",
+        "document_type" => "gone",
+        "schema_name" => "gone",
         "publishing_app" => "contacts",
         "routes" => [
           {

--- a/spec/lib/redirector_for_gone_contact_spec.rb
+++ b/spec/lib/redirector_for_gone_contact_spec.rb
@@ -94,8 +94,6 @@ describe RedirectorForGoneContact do
           ->(request) do
             data = JSON.parse(request.body)
             # RSpec 2.14 doesn't have a fluent interface for this kind of match
-            expect(data).to have_key('format')
-            expect(data['format']).to eq('redirect')
             expect(data).to have_key('redirects')
             expect(data['redirects'].size).to eq(1)
             redirect = data['redirects'].first

--- a/spec/presenters/contact_gone_presenter_spec.rb
+++ b/spec/presenters/contact_gone_presenter_spec.rb
@@ -9,7 +9,6 @@ describe ContactGonePresenter do
   let(:payload) { subject.present }
 
   it "transforms a contact to the correct format" do
-    expect(payload[:format]).to eq('gone')
     expect(payload[:publishing_app]).to eq("contacts")
     expect(payload[:routes].first[:path]).to eq(contact.link)
     expect(payload[:base_path]).to eq(contact.link)

--- a/spec/presenters/contact_redirect_presenter_spec.rb
+++ b/spec/presenters/contact_redirect_presenter_spec.rb
@@ -10,7 +10,6 @@ describe ContactRedirectPresenter do
   let(:payload) { subject.present }
 
   it "transforms a contact to the redirect format" do
-    expect(payload[:format]).to eq('redirect')
     expect(payload[:publishing_app]).to eq("contacts")
     expect(payload[:redirects].size).to eq(1)
     expect(payload[:base_path]).to eq(contact.link)


### PR DESCRIPTION
`document_type` and `schema_name` have replaced `format`.

I've removed some tests rather than updating them, because they duplicated the implementation. The schema tests seem sufficient here.

Related: https://github.com/alphagov/govuk-content-schemas/pull/348