### PR TITLE
Add `organisation_content_id` string field to User

### DIFF
--- a/db/migrate/20160920172304_add_organisation_content_id_to_users.rb
+++ b/db/migrate/20160920172304_add_organisation_content_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddOrganisationContentIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :organisation_content_id, :string
+    add_column :users, :disabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420132844) do
+ActiveRecord::Schema.define(version: 20160920172304) do
 
   create_table "contact_groups", force: :cascade do |t|
     t.integer  "contact_group_type_id", limit: 4
@@ -152,15 +152,17 @@ ActiveRecord::Schema.define(version: 20160420132844) do
   add_index "post_addresses", ["contact_id"], name: "index_post_addresses_on_contact_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                limit: 255
-    t.string   "email",               limit: 255
-    t.string   "uid",                 limit: 255
-    t.integer  "version",             limit: 4
-    t.text     "permissions",         limit: 65535
-    t.boolean  "remotely_signed_out",               default: false
+    t.string   "name",                    limit: 255
+    t.string   "email",                   limit: 255
+    t.string   "uid",                     limit: 255
+    t.integer  "version",                 limit: 4
+    t.text     "permissions",             limit: 65535
+    t.boolean  "remotely_signed_out",                   default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "organisation_slug",   limit: 255
+    t.string   "organisation_slug",       limit: 255
+    t.string   "organisation_content_id", limit: 255
+    t.boolean  "disabled",                              default: false
   end
 
   create_table "versions", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
+require 'gds-sso/lint/user_spec'
 
 RSpec.describe User, type: :model do
+  it_behaves_like "a gds-sso user class"
+
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_presence_of :email }
 end


### PR DESCRIPTION
Gds-sso gem version 11.0 introduced the required fields `disabled` and `organisation_content_id`. This was missed when the gem was upgraded to 12.1.0 recently, thereby breaking admin authentication. This commit adds the migration for those two fields.

https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md#1010-includes-a-breaking-change