### PR TITLE
Update gds api adapters behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "virtus", "~> 1.0.5"
 gem "paper_trail", "~> 5.2.0"
 gem "govspeak", "~> 3.6.0"
 gem "gds-sso", "~> 12.1.0"
-gem 'gds-api-adapters', "35.0.0"
+gem 'gds-api-adapters', "36.0.1"
 gem "lrucache", "0.1.4"
 gem "plek", ">= 1.12.0"
 gem 'govuk_admin_template', '4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
-    gds-api-adapters (35.0.0)
+    gds-api-adapters (36.0.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -379,7 +379,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.7)
   fakefs (= 0.9.1)
   friendly_id (= 5.1.0)
-  gds-api-adapters (= 35.0.0)
+  gds-api-adapters (= 36.0.1)
   gds-sso (~> 12.1.0)
   govspeak (~> 3.6.0)
   govuk-content-schema-test-helpers (= 1.4.0)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -40,11 +40,11 @@ class Contact < ActiveRecord::Base
 
   def quick_links
     links = [
-      OpenStruct.new(title: quick_link_title_1, url: quick_link_1),
-      OpenStruct.new(title: quick_link_title_2, url: quick_link_2),
-      OpenStruct.new(title: quick_link_title_3, url: quick_link_3),
+      { title: quick_link_title_1, url: quick_link_1 },
+      { title: quick_link_title_2, url: quick_link_2 },
+      { title: quick_link_title_3, url: quick_link_3 },
     ]
-    links.reject { |link| link.title.blank? || link.url.blank? }
+    links.reject { |link| link[:title].blank? || link[:url].blank? }
   end
 
   def to_s

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,8 +1,6 @@
 require "lrucache"
 
 class WorldLocation
-  extend Forwardable
-
   def self.cache
     @cache ||= LRUCache.new(soft_ttl: 24.hours, ttl: 1.week)
   end
@@ -14,7 +12,7 @@ class WorldLocation
   def self.all
     cache_fetch("all") do
       Services.worldwide_api.world_locations.with_subsequent_pages
-        .map { |l| new(l) if l.format == "World location" && l.details && l.details.slug.present? }
+        .map { |l| new(l) if l["format"] == "World location" && l["details"] && l["details"]["slug"].present? }
         .compact
     end
   end
@@ -56,7 +54,11 @@ class WorldLocation
     other.is_a?(self.class) && other.slug == slug
   end
 
-  def_delegators :@data, :title, :details
-  def_delegators :details, :slug
-  alias_method :name, :title
+  def slug
+    @data["details"]["slug"]
+  end
+
+  def title
+    @data["title"]
+  end
 end

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -54,7 +54,7 @@ private
       slug: contact.slug,
       title: contact.title,
       description: contact.description,
-      quick_links: contact.quick_links.map { |q| { title: q.title, url: q.url } },
+      quick_links: contact.quick_links.map { |q| { title: q[:title], url: q[:url] } },
       query_response_time: (contact.query_response_time || false),
 
       contact_form_links: ContactFormLinksPresenter.new(contact.contact_form_links).present,

--- a/app/presenters/post_addresses_presenter.rb
+++ b/app/presenters/post_addresses_presenter.rb
@@ -8,13 +8,13 @@ class PostAddressesPresenter
   def present
     @post_addresses.map do |post|
       {
-        title: post.title,
-        street_address: post.street_address,
-        postal_code: post.postal_code,
+        title: post[:title],
+        street_address: post[:street_address],
+        postal_code: post[:postal_code],
         world_location: post.world_location.title,
-        locality: post.locality,
-        region: post.region,
-        description: govspeak(post.description),
+        locality: post[:locality],
+        region: post[:region],
+        description: govspeak(post[:description]),
       }
     end
   end

--- a/app/tasks/import_organisations.rb
+++ b/app/tasks/import_organisations.rb
@@ -5,7 +5,7 @@ class ImportOrganisations
     organisation_relationships = {}
     organisations.each do |organisation_data|
       update_or_create_organisation(organisation_data)
-      organisation_relationships[organisation_data.details.slug] = child_organisation_slugs(organisation_data)
+      organisation_relationships[organisation_data["details"]["slug"]] = child_organisation_slugs(organisation_data)
     end
     update_ancestry(organisation_relationships)
   rescue ActiveRecord::RecordInvalid => invalid
@@ -20,19 +20,20 @@ private
   end
 
   def update_or_create_organisation(organisation_data)
-    organisation = Organisation.find_or_create_by(slug: organisation_data.details.slug)
+    organisation = Organisation.find_or_create_by(slug: organisation_data["details"]["slug"])
     update_data = {
-      title: organisation_data.title,
-      format: organisation_data.format,
-      abbreviation: organisation_data.details.abbreviation,
-      govuk_status: organisation_data.details.govuk_status,
-      content_id: organisation_data.details.content_id
+      title: organisation_data["title"],
+      format: organisation_data["format"],
+      abbreviation: organisation_data["details"]["abbreviation"],
+      govuk_status: organisation_data["details"]["govuk_status"],
+      content_id: organisation_data["details"]["content_id"]
     }
     organisation.update_attributes!(update_data)
   end
 
   def child_organisation_slugs(organisation_data)
-    organisation_data.child_organisations.map(&:id).collect { |child_organisation_id| child_organisation_id.split('/').last }
+    organisation_data["child_organisations"].map { |child| child["id"] }
+      .collect { |child_organisation_id| child_organisation_id.split('/').last }
   end
 
   def update_ancestry(organisation_relationships)

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,3 +1,4 @@
 GdsApi.configure do |config|
   config.always_raise_for_not_found = true
+  config.hash_response_for_requests = true
 end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -31,7 +31,7 @@ describe ContactPresenter do
 
       details = payload[:details]
       expect(details[:description]).to eq(contact.description)
-      expect(details[:quick_links]).to eq(contact.quick_links.map { |q| { title: q.title, url: q.url } })
+      expect(details[:quick_links]).to eq(contact.quick_links.map { |q| { title: q[:title], url: q[:url] } })
       expect(details[:contact_form_links]).to eq(contact.contact_form_links.map(&:as_json))
       expect(details[:more_info_email_address]).to include("<li>")
       expect(details[:more_info_phone_number]).to include("<li>")

--- a/spec/support/mock_organisations_api.rb
+++ b/spec/support/mock_organisations_api.rb
@@ -5,17 +5,17 @@ class MockOrganisationsApi
 
   def with_subsequent_pages
     [
-      OpenStruct.new(id: "hmrc",
-                     title: "HM Revenue & Customs",
-                     format: "Ministerial department",
-                     updated_at: "2013-08-22T11:02:18+01:00",
-                     web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
-                     child_organisations: [],
-                     parent_organisations: [],
-                     details: OpenStruct.new(slug: "hm-revenue-customs",
-                                             abbreviation: "HMRC",
-                                             closed_at: nil,
-                                             govuk_status: "live"))
+      { id: "hmrc",
+        title: "HM Revenue & Customs",
+        format: "Ministerial department",
+        updated_at: "2013-08-22T11:02:18+01:00",
+        web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        child_organisations: [],
+        parent_organisations: [],
+        details: { slug: "hm-revenue-customs",
+                   abbreviation: "HMRC",
+                   closed_at: nil,
+                   govuk_status: "live" } }
     ]
   end
 end

--- a/spec/support/shared_contexts/mock_world_location.rb
+++ b/spec/support/shared_contexts/mock_world_location.rb
@@ -1,8 +1,23 @@
-require "ostruct"
-
 shared_context "mock world location", mock_world_location: true do
-  before {
-    allow(WorldLocation).to receive(:all).and_return([OpenStruct.new(slug: "united-kingdom", title: "United Kingdom ")])
-    allow(WorldLocation).to receive(:find).and_return(OpenStruct.new(slug: "united-kingdom", title: "United Kingdom "))
-  }
+  before do
+    allow(WorldLocation).to receive(:all).and_return(
+      [
+        WorldLocation.new(
+          "title" => "United Kingdom ",
+            "details" => {
+              "slug" => "united-kingdom",
+            }
+        )
+      ]
+    )
+
+    allow(WorldLocation).to receive(:find).and_return(
+      WorldLocation.new(
+        "title" => "United Kingdom ",
+          "details" => {
+            "slug" => "united-kingdom",
+          }
+      )
+    )
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/B5z6Dq8q/)

Some old behaviour has been deprecated in [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) so we are updating this app to comply with this before it becomes the default. Firstly, a GdsApi::NotFound error is now raised when the server returns a 404 or 410.  Secondly, requests now return a hash instead of an OpenStruct.  We have now opted in to this new behaviour.

OpenStructs have been converted to hashes where necessary, and where this data is being accessed has been modified accordingly.  In particular, we have removed delegator methods from WorldLocation and replaced them with separate methods as they are no longer suitable to retrieve title and slug information.

As part of this work, we made a change to gds-api-adapters to ensure a results hash is returned in ListReponse instead of an OpenStruct when apps are opted in to the new behaviour.