### PR TITLE
Migrate the HMRC contacts page to finder-frontend

### DIFF
--- a/app/controllers/admin/contact_groups_controller.rb
+++ b/app/controllers/admin/contact_groups_controller.rb
@@ -11,6 +11,7 @@ class Admin::ContactGroupsController < AdminController
 
   def update
     if @contact_group.update_attributes(contact_group_params)
+      republish_finders
       redirect_to admin_contact_groups_path, notice: "Contact Group successfully updated"
     else
       render :edit
@@ -20,6 +21,7 @@ class Admin::ContactGroupsController < AdminController
   def create
     @contact_group = ContactGroup.new(contact_group_params)
     if @contact_group.save
+      republish_finders
       redirect_to admin_contact_groups_path, notice: "Contact Group successfully created"
     else
       render :new
@@ -28,6 +30,7 @@ class Admin::ContactGroupsController < AdminController
 
   def destroy
     if Admin::DestroyContactGroup.new(@contact_group).destroy
+      republish_finders
       flash.notice = "Contact Group successfully deleted"
     else
       flash.alert = @contact_group.errors.full_messages.to_sentence
@@ -49,5 +52,9 @@ private
       :title,
       :organisation_id
     )
+  end
+
+  def republish_finders
+    PublishFinders.call
   end
 end

--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -13,6 +13,7 @@ class ContactRummagerPresenter
       format: "contact",
       indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
       public_timestamp: contact.updated_at,
+      contact_groups: contact.contact_groups.map(&:slug)
     }
   end
 end

--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -1,0 +1,72 @@
+# This service currently only publishes the HMRC contacts finder since this app
+# only contains contacts related to HMRC.
+class PublishFinders
+  def self.call
+    new.call
+  end
+
+  def call
+    Services.publishing_api.put_content(
+      HMRC_CONTACTS_CONTENT_ID,
+      hmrc_contacts_payload
+    )
+    Services.publishing_api.publish(HMRC_CONTACTS_CONTENT_ID, "major")
+  end
+
+private
+
+  HMRC_CONTACTS_CONTENT_ID = "b110c03c-3f8d-4327-906b-17ebd872e6a6".freeze
+
+  def hmrc_contacts_payload
+    {
+      "base_path": "/government/organisations/hm-revenue-customs/contact",
+      "title": "HM Revenue & Customs Contacts",
+      "description": "",
+      "locale": "en",
+      "document_type": "finder",
+      "schema_name": "finder",
+      "publishing_app": "contacts",
+      "rendering_app": "finder-frontend",
+      "details": {
+        "document_noun": "contact",
+        "default_order": "title",
+        "facets": [
+          {
+            "key": "contact_groups",
+            "name": "Topics",
+            "type": "text",
+            "preposition": "in topic",
+            "display_as_result_metadata": false,
+            "filterable": true,
+            "allowed_values": contact_groups_hash
+          }
+        ],
+        "filter": {
+          "format": "contact"
+        },
+        "format_name": "HM Revenue & Customs Contacts",
+        "show_summaries": true
+      },
+      "routes": [
+        {
+          "type": "exact",
+          "path": "/government/organisations/hm-revenue-customs/contact"
+        },
+        {
+          "type": "exact",
+          "path": "/government/organisations/hm-revenue-customs/contact.json"
+        }
+      ]
+    }
+  end
+
+  def contact_groups_hash
+    contact_groups = ContactGroup.order("title ASC").all
+    contact_groups.map do |contact_group|
+      {
+        label: contact_group.title,
+        value: contact_group.slug
+      }
+    end
+  end
+end

--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -1,0 +1,7 @@
+namespace :finders do
+  desc 'Publish finder pages to the publishing API'
+  task publish: :environment do
+    puts "Publishing finders"
+    PublishFinders.call
+  end
+end

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -13,6 +13,7 @@ describe ContactRummagerPresenter do
       format:            'contact',
       indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
       public_timestamp:  contact.updated_at,
+      contact_groups:    [contact.contact_groups.first.slug],
     }
 
     expect(ContactRummagerPresenter.new(contact).present).to eql(expected)

--- a/spec/schemas/finder_schema_validation_spec.rb
+++ b/spec/schemas/finder_schema_validation_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 'govuk-content-schema-test-helpers/rspec_matchers'
+
+RSpec.describe "FinderSchemaValidation" do
+  include GovukContentSchemaTestHelpers::RSpecMatchers
+
+  it "validates the contacts finder is a valid finder" do
+    contacts_finder = PublishFinders.new.send(:hmrc_contacts_payload)
+
+    expect(contacts_finder).to be_valid_against_schema('finder')
+  end
+end

--- a/spec/services/publish_finders_spec.rb
+++ b/spec/services/publish_finders_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe PublishFinders do
+  before do
+    @hmrc_contacts_content_id = PublishFinders::HMRC_CONTACTS_CONTENT_ID
+    @hmrc_contacts_finder = PublishFinders.new.send(:hmrc_contacts_payload)
+  end
+
+  it 'publishes the HMRC contacts finder' do
+    PublishFinders.call
+
+    assert_publishing_api_put_content(@hmrc_contacts_content_id, @hmrc_contacts_finder)
+    assert_publishing_api_publish(@hmrc_contacts_content_id, update_type: 'major')
+  end
+end


### PR DESCRIPTION
This commit migrates the rendering of the HMRC contacts page at https://www.gov.uk/government/organisations/hm-revenue-customs/contact from contacts-admin to finder-frontend, since the formats are so similar.

A service and rake task are provided to publish the finder to the Publishing API. This also happens every time a contact group is added/edited/deleted in the admin interface since the contact groups are included in the JSON that is sent to the Publishing API.

Finally, contact groups are sent to rummager to be indexed so that the finder facets work.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder

Paired with @klssmith 

A follow-up PR will remove the code that renders the current version of the page in this app.

Deployment checklist
- [ ] Deploy contacts-admin
- [ ] Run rake task `contacts:republish` to re-publish all existing contacts with their corresponding contact groups
- [ ] Run rake task `finders:publish` to publish the finder JSON