### PR TITLE
Set the parent of the HMRC contacts finder

### DIFF
--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -11,6 +11,10 @@ class PublishFinders
       hmrc_contacts_payload
     )
     Services.publishing_api.publish(HMRC_CONTACTS_CONTENT_ID, "major")
+    Services.publishing_api.patch_links(
+      HMRC_CONTACTS_CONTENT_ID,
+      links: hmrc_contacts_parent
+    )
   end
 
 private
@@ -56,6 +60,15 @@ private
           "type": "exact",
           "path": "/government/organisations/hm-revenue-customs/contact.json"
         }
+      ]
+    }
+  end
+
+  def hmrc_contacts_parent
+    # Sets the parent of the HMRC contacts finder to the HMRC organisation page
+    {
+      parent: [
+        "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
       ]
     }
   end

--- a/spec/services/publish_finders_spec.rb
+++ b/spec/services/publish_finders_spec.rb
@@ -4,12 +4,23 @@ RSpec.describe PublishFinders do
   before do
     @hmrc_contacts_content_id = PublishFinders::HMRC_CONTACTS_CONTENT_ID
     @hmrc_contacts_finder = PublishFinders.new.send(:hmrc_contacts_payload)
+    @hmrc_contacts_parent = PublishFinders.new.send(:hmrc_contacts_parent)
   end
 
   it 'publishes the HMRC contacts finder' do
     PublishFinders.call
 
-    assert_publishing_api_put_content(@hmrc_contacts_content_id, @hmrc_contacts_finder)
-    assert_publishing_api_publish(@hmrc_contacts_content_id, update_type: 'major')
+    assert_publishing_api_put_content(
+      @hmrc_contacts_content_id,
+      @hmrc_contacts_finder
+    )
+    assert_publishing_api_publish(
+      @hmrc_contacts_content_id,
+      update_type: 'major'
+    )
+    assert_publishing_api_patch_links(
+      @hmrc_contacts_content_id,
+      links: @hmrc_contacts_parent
+    )
   end
 end


### PR DESCRIPTION
This commit sets the parent of the HMRC contacts finder to the HMRC organisation page. This will allow finder-frontend to display the correct breadcrumbs for the finder, once https://github.com/alphagov/finder-frontend/pull/259 has been deployed.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder

Before:

![screen shot 2016-11-07 at 13 38 57](https://cloud.githubusercontent.com/assets/444232/20059855/263d26d0-a4f0-11e6-93ba-e6031b328647.png)

After:

![screen shot 2016-11-07 at 13 43 05](https://cloud.githubusercontent.com/assets/444232/20059859/2b225ca6-a4f0-11e6-9f8c-3a6f396d4210.png)
