### PR TITLE
Alias finders:publish rake task

### DIFF
--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -5,3 +5,6 @@ namespace :finders do
     PublishFinders.call
   end
 end
+
+# Alias of the above task for the benefit of` govuk-app-deployment`
+task "publishing_api:publish": "finders:publish"


### PR DESCRIPTION
This commit aliases the `finders:publish` rake task to `publishing_api:publish`, which allows `govuk-app-deployment` to use an existing `capistrano` task during deployment to run this rake task.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder