### PR TITLE
Remove “enable_admin_routes”

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,9 +45,5 @@ Rails.application.configure do
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end
 
-  config.after_initialize do
-    Contacts.enable_admin_routes = true
-  end
-
   config.assets.quiet = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,5 @@ Rails.application.configure do
 
   config.after_initialize do
     PaperTrail.enabled = false
-    Contacts.enable_admin_routes = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,30 +1,22 @@
-class AdminRequest
-  def self.matches?(request)
-    Contacts.enable_admin_routes || ENV["ENABLE_ADMIN_ROUTES"].present?
-  end
-end
-
 Rails.application.routes.draw do
   get "healthcheck" => "healthcheck#check"
 
   # Permanently redirect any requests for the root URL to /admin
   root :to => redirect("/admin", status: 301)
 
-  constraints(AdminRequest) do
-    namespace :admin do
-      root to: 'contacts#index', via: :get
+  namespace :admin do
+    root to: 'contacts#index', via: :get
 
-      resources :contact_groups
-      resources :contacts do
-        member do
-          get :clone
-        end
-        scope module: 'contacts' do
-          resources :contact_form_links
-          resources :email_addresses
-          resources :post_addresses
-          resources :phone_numbers
-        end
+    resources :contact_groups
+    resources :contacts do
+      member do
+        get :clone
+      end
+      scope module: 'contacts' do
+        resources :contact_form_links
+        resources :email_addresses
+        resources :post_addresses
+        resources :phone_numbers
       end
     end
   end

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -4,6 +4,5 @@ module Contacts
   mattr_accessor :rummager_client
   mattr_accessor :worldwide_api
   mattr_accessor :organisations_api
-  mattr_accessor :enable_admin_routes
   mattr_accessor :publishing_api
 end


### PR DESCRIPTION
Noe that contacts-admin is a purely admin app with no frontend code, and only deployed to backend servers, we no longer need to disable the admin routes on frontend servers.