### PR TITLE
Change assets config to serve all assets locally

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,8 +22,6 @@ module Contacts
       admin.js
     )
 
-    config.assets.prefix = '/contacts-assets'
-
     config.i18n.enforce_available_locales = true
 
     # Do not swallow errors in after_commit/after_rollback callbacks.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,10 +40,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  if ENV['GOVUK_ASSET_ROOT'].present?
-    config.asset_host = ENV['GOVUK_ASSET_ROOT']
-  end
-
-  config.assets.quiet = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,6 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
-  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
contacts-admin currently serves all assets via the assets server. Now that it is no longer a frontend app, assets can be served locally, which also brings it into line with other admin-only apps.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder