### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -9,7 +9,7 @@ bundle exec rake assets:precompile --trace
 
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas COVERAGE=on bundle exec rake ci:setup:rspec spec --trace
 


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Contacts Admin app that don't
work with the currently deployed govuk-content-schemas (this changes
comes from GOV.UK RFC 59).