### PR TITLE
Register Document Type with Rummager

### DIFF
--- a/app/presenters/contact_rummager_presenter.rb
+++ b/app/presenters/contact_rummager_presenter.rb
@@ -13,7 +13,8 @@ class ContactRummagerPresenter
       format: "contact",
       indexable_content: "#{contact.title} #{contact.description} #{contact.contact_groups.map(&:title).join}",
       public_timestamp: contact.updated_at,
-      contact_groups: contact.contact_groups.map(&:slug)
+      contact_groups: contact.contact_groups.map(&:slug),
+      content_store_document_type: "contact",
     }
   end
 end


### PR DESCRIPTION
We need to be able to filter Rummager on document_type for Guidance content, so this change updates Searchable to present the document type for all "Editions".

This has been tested locally by running the `contacts:republish` Rake task and checking that the `content_store_document_type` was present on a given document.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager