### PR TITLE
Fix broken tests on master and enable Jenkins to run the tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ node {
 
     stage('Tests') {
       govuk.runRakeTask('ci:setup:rspec spec')
+      govuk.runTests()
       govuk.rubyLinter()
     }
 

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -24,7 +24,7 @@ describe ContactPresenter do
       expect(payload[:title]).to eq(contact.title)
       expect(payload[:description]).to eq(contact.description)
       expect(payload[:publishing_app]).to eq("contacts")
-      expect(payload[:rendering_app]).to eq("contacts-frontend")
+      expect(payload[:rendering_app]).to eq("government-frontend")
       expect(payload[:routes].first[:path]).to eq(contact.link)
       expect(payload[:public_updated_at]).to be_present
       expect(payload[:need_ids]).to be_empty

--- a/spec/presenters/contact_rummager_presenter_spec.rb
+++ b/spec/presenters/contact_rummager_presenter_spec.rb
@@ -12,6 +12,7 @@ describe ContactRummagerPresenter do
       link:              "/government/organisations/#{contact.organisation.slug}/contact/major-tom",
       format:            'contact',
       indexable_content: "Major Tom Back to Earth #{contact.contact_groups.first.title}",
+      content_store_document_type: "contact",
       public_timestamp:  contact.updated_at,
       contact_groups:    [contact.contact_groups.first.slug],
     }


### PR DESCRIPTION
While working on contacts admin, it turned out that the tests are not running on jenkins :man_facepalming: and there was some broken tests, this re enables jenkins running the tests and fixes the broken tests

example of tests not running
https://ci.integration.publishing.service.gov.uk/job/contacts/job/change-rendering-app/3/
with this branch
https://ci.integration.publishing.service.gov.uk/job/contacts/job/fix-broken-tests-on-master/1/

https://trello.com/c/pIBrqrZX