### PR TITLE
Add in parent link for the generation of links government frontend

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -41,6 +41,7 @@ class ContactPresenter
     {
       links: {
         "related" => @contact.related_contacts.pluck(:content_id),
+        "parent"  => [PublishFinders::HMRC_CONTACTS_CONTENT_ID]
       }
     }
   end

--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -1,6 +1,8 @@
 # This service currently only publishes the HMRC contacts finder since this app
 # only contains contacts related to HMRC.
 class PublishFinders
+  HMRC_CONTACTS_CONTENT_ID = "b110c03c-3f8d-4327-906b-17ebd872e6a6".freeze
+
   def self.call
     new.call
   end
@@ -18,8 +20,6 @@ class PublishFinders
   end
 
 private
-
-  HMRC_CONTACTS_CONTENT_ID = "b110c03c-3f8d-4327-906b-17ebd872e6a6".freeze
 
   def hmrc_contacts_payload
     {

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -51,6 +51,7 @@ describe ContactPresenter do
       links = ContactPresenter.new(contact).links
 
       expect(links[:links]["related"]).to eq([content_id])
+      expect(links[:links]["parent"]).to eq([PublishFinders::HMRC_CONTACTS_CONTENT_ID])
     end
   end
 


### PR DESCRIPTION
This adds in the parent link, this is hardcoded currently in
government frontend, this pull should enable us to do it in
the standard govuk way