### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "virtus", "~> 1.0.5"
 gem "paper_trail", "~> 7.0.2"
 gem "govspeak", "~> 3.6.2"
 gem "gds-sso", "~> 13.2.0"
-gem 'gds-api-adapters', "36.0.1"
+gem 'gds-api-adapters', "~> 47.2"
 gem "lrucache", "0.1.4"
 gem "plek", ">= 1.12.0"
 gem 'govuk_admin_template', '4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
@@ -106,7 +106,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (36.0.1)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -144,7 +144,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.5.5)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.1)
     ice_nine (0.11.2)
@@ -212,7 +212,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (2.0.3)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -246,7 +246,7 @@ GEM
     redis (3.3.1)
     ref (2.0.0)
     request_store (1.3.2)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -330,7 +330,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.0)
     unicorn (5.1.0)
       kgio (~> 2.6)
@@ -370,7 +370,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.7, >= 4.7.0)
   fakefs (= 0.9.1)
   friendly_id (= 5.2.1)
-  gds-api-adapters (= 36.0.1)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.2.0)
   govspeak (~> 3.6.2)
   govuk-content-schema-test-helpers (= 1.4.0)
@@ -403,4 +403,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.14.5
+   1.15.0

--- a/app/lib/publisher.rb
+++ b/app/lib/publisher.rb
@@ -34,8 +34,8 @@ private
   end
 
   def publish_item
-    Publisher.client.publish(presenter.content_id,
-                            "major",
-                             locale: presenter.payload[:locale])
+    Publisher.client.publish(
+      presenter.content_id, locale: presenter.payload[:locale]
+    )
   end
 end

--- a/app/presenters/contact_gone_presenter.rb
+++ b/app/presenters/contact_gone_presenter.rb
@@ -18,6 +18,7 @@ class ContactGonePresenter
       routes: [
         { path: contact.link, type: "exact" }
       ],
+      update_type: "major",
     }
   end
 

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -27,6 +27,7 @@ class ContactPresenter
       ],
       details: contact_details.merge(language: "en"),
       need_ids: [],
+      update_type: "major",
     }
   end
 

--- a/app/presenters/contact_redirect_presenter.rb
+++ b/app/presenters/contact_redirect_presenter.rb
@@ -21,6 +21,7 @@ class ContactRedirectPresenter
           destination: redirect_to_location
         }
       ],
+      update_type: "major",
     }
   end
 

--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -12,7 +12,7 @@ class PublishFinders
       HMRC_CONTACTS_CONTENT_ID,
       hmrc_contacts_payload
     )
-    Services.publishing_api.publish(HMRC_CONTACTS_CONTENT_ID, "major")
+    Services.publishing_api.publish(HMRC_CONTACTS_CONTENT_ID)
     Services.publishing_api.patch_links(
       HMRC_CONTACTS_CONTENT_ID,
       links: hmrc_contacts_parent
@@ -31,6 +31,7 @@ private
       "schema_name": "finder",
       "publishing_app": "contacts",
       "rendering_app": "finder-frontend",
+      "update_type": "major",
       "details": {
         "document_noun": "contact",
         "default_order": "title",

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,4 +1,0 @@
-GdsApi.configure do |config|
-  config.always_raise_for_not_found = true
-  config.hash_response_for_requests = true
-end

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -28,7 +28,6 @@ describe Publisher do
       it 'calls publish' do
         expect(Publisher.client).to receive(:publish)
           .with(contact.content_id,
-                "major",
                 locale: presenter.payload[:locale])
 
         Publisher.new(presenter).publish

--- a/spec/services/publish_finders_spec.rb
+++ b/spec/services/publish_finders_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe PublishFinders do
     )
     assert_publishing_api_publish(
       @hmrc_contacts_content_id,
-      update_type: 'major'
     )
     assert_publishing_api_patch_links(
       @hmrc_contacts_content_id,


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)