### PR TITLE
Call publishing_api.publish correctly

### DIFF
--- a/app/lib/publisher.rb
+++ b/app/lib/publisher.rb
@@ -35,7 +35,7 @@ private
 
   def publish_item
     Publisher.client.publish(
-      presenter.content_id, locale: presenter.payload[:locale]
+      presenter.content_id, nil, locale: presenter.payload[:locale]
     )
   end
 end

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -28,6 +28,7 @@ describe Publisher do
       it 'calls publish' do
         expect(Publisher.client).to receive(:publish)
           .with(contact.content_id,
+                nil,
                 locale: presenter.payload[:locale])
 
         Publisher.new(presenter).publish


### PR DESCRIPTION
The second argument is update_type, so if we're not going to be using it, we need to set it to `nil`.