### PR TITLE
Replace Airbrake monitoring with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ gem "paper_trail", "~> 7.0.2"
 gem "govspeak", "~> 3.6.2"
 gem "gds-sso", "~> 13.2.0"
 gem 'gds-api-adapters', "~> 47.2"
+gem "govuk_app_config", "~> 0.2.0"
 gem "lrucache", "0.1.4"
 gem "plek", ">= 1.12.0"
 gem 'govuk_admin_template', '4.3.0'
 gem "mlanett-redis-lock", "0.2.7"
-gem "airbrake", "4.3.8"
 gem "whenever", "~> 0.9.7"
 gem "searchlight", "4.1.0"
 gem 'ancestry', '2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.8)
-      builder
-      multi_json
     ancestry (2.1.0)
       activerecord (>= 3.0.0)
     arel (7.1.4)
@@ -106,7 +103,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (47.2.0)
+    gds-api-adapters (47.9.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -138,6 +135,9 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.1.1)
       rails (>= 3.2.0)
+    govuk_app_config (0.2.0)
+      sentry-raven (~> 2.6.3)
+      statsd-ruby (~> 1.4.0)
     govuk_frontend_toolkit (4.17.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -203,7 +203,7 @@ GEM
       request_store (~> 1.1)
     parser (2.3.1.2)
       ast (~> 2.2)
-    plek (1.12.0)
+    plek (2.0.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -212,7 +212,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (2.0.3)
-    rack-cache (1.7.0)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -294,6 +294,8 @@ GEM
     searchlight (4.1.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
+    sentry-raven (2.6.3)
+      faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simple_form (3.3.1)
@@ -314,6 +316,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -361,7 +364,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash (= 1.4.1)
-  airbrake (= 4.3.8)
   ancestry (= 2.1.0)
   better_errors
   binding_of_caller
@@ -376,6 +378,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (= 1.4.0)
   govuk-lint (= 1.2.1)
   govuk_admin_template (= 4.3.0)
+  govuk_app_config (~> 0.2.0)
   govuk_frontend_toolkit (~> 4.17.0)
   json-schema (= 2.5.2)
   lrucache (= 0.1.4)
@@ -403,4 +406,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/app/lib/publisher.rb
+++ b/app/lib/publisher.rb
@@ -15,7 +15,7 @@ class Publisher
     publish_item
     true
   rescue GdsApi::HTTPErrorResponse => e
-    Airbrake.notify_or_ignore(e)
+    GovukError.notify(e)
     false
   end
 

--- a/spec/lib/publisher_spec.rb
+++ b/spec/lib/publisher_spec.rb
@@ -58,7 +58,7 @@ describe Publisher do
         before { stub_any_publishing_api_put_content.to_return(status: 422, body: "Failed put content") }
 
         it "returns false and logs an error in Errbit" do
-          expect(Airbrake).to receive(:notify_or_ignore)
+          expect(GovukError).to receive(:notify)
           response = Publisher.new(presenter).publish
 
           expect(response).to be_falsey
@@ -69,7 +69,7 @@ describe Publisher do
         before { stub_any_publishing_api_patch_links.to_return(status: 422, body: "Failed put links") }
 
         it "returns false and logs an error in Errbit" do
-          expect(Airbrake).to receive(:notify_or_ignore)
+          expect(GovukError).to receive(:notify)
           response = Publisher.new(presenter).publish
 
           expect(response).to be_falsey
@@ -80,7 +80,7 @@ describe Publisher do
         before { stub_any_publishing_api_call.to_return(status: 422, body: "Failed publish") }
 
         it "returns false and logs an error in Errbit" do
-          expect(Airbrake).to receive(:notify_or_ignore)
+          expect(GovukError).to receive(:notify)
           response = Publisher.new(presenter).publish
 
           expect(response).to be_falsey


### PR DESCRIPTION
We're moving away from Errbit because it's an unsupported fork, isn't
meeting our needs very well and complicates the move to AWS. We're going
for Sentry because most people seem to like it, used by other teams in
GDS, it's modern and up-to-date and we can use a SaaS version.

https://trello.com/c/DJ7h8C1b/306-make-sure-the-apps-we-support-are-migrated-to-sentry
https://trello.com/c/TvhWdRDI/40-update-contacts-admin

Paired with @Rosa-Fox 