### PR TITLE
Send contact_groups to the publishing-api

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -70,6 +70,7 @@ private
 
       post_addresses: PostAddressesPresenter.new(contact.post_addresses).present,
       more_info_post_address: govspeak(contact.more_info_post_address),
+      contact_groups: contact.contact_groups.map { |group| { title: group.title, slug: group.slug } }
     }
   end
 end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -36,6 +36,18 @@ describe ContactPresenter do
       expect(details[:more_info_email_address]).to include("<li>")
       expect(details[:more_info_phone_number]).to include("<li>")
     end
+
+    it "presents contact with contact_groups correctly against the schema" do
+      contact_with_groups = create :contact, :with_contact_group
+      payload = ContactPresenter.new(contact_with_groups).payload
+
+      expect(payload.to_json).to be_valid_against_schema('contact')
+
+      contact_groups = payload[:details][:contact_groups]
+      expect(contact_groups.count).to eq(contact_with_groups.contact_groups.count)
+      expect(contact_groups.first[:title]).to eq(contact_with_groups.contact_groups.first.title)
+      expect(contact_groups.first[:slug]).to eq(contact_with_groups.contact_groups.first.slug)
+    end
   end
 
   context "#links" do


### PR DESCRIPTION
[Trello](https://trello.com/c/KX2WILnc/332-add-contactgroups-to-publishing-api)
- Part of the work to migrate contacts_admin to use the govuk_index.
- Previously publishing-api did not have the contact_groups fields.
- They are now needed so that publishing-api can send them to Rummager, as opposed to contacts-admin sending them straight to Rummager.

Depends on [this change](https://github.com/alphagov/govuk-content-schemas/commit/a20b6ae73d0f9668b2e026dd2a653bd4a02c241e) to content-schemas being deployed.

Paired with @suzannehamilton.