### PR TITLE
Stop talking about the design principles style guide

### DIFF
--- a/app/views/admin/shared/_formatting.html.erb
+++ b/app/views/admin/shared/_formatting.html.erb
@@ -8,7 +8,7 @@
         </h3>
       </div>
       <div class="modal-body">
-        <p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a>
+        <p>For style, see the <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing">style guide</a>
         <h4>Links</h4>
         <pre>[link text](http://www.example.com) </pre>
         <p>For external websites, use the full URL including http://:, The link will display with an external link symbol.</p>


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

That route has been retired in favour of a new one and we might as well
save a redirect.