### PR TITLE
Rename the finder to "Contact HM Revenue & Customs"

### DIFF
--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -24,7 +24,7 @@ private
   def hmrc_contacts_payload
     {
       "base_path": "/government/organisations/hm-revenue-customs/contact",
-      "title": "HM Revenue & Customs Contacts",
+      "title": "Contact HM Revenue & Customs",
       "description": "",
       "locale": "en",
       "document_type": "finder",
@@ -49,7 +49,7 @@ private
         "filter": {
           "format": "contact"
         },
-        "format_name": "HM Revenue & Customs Contacts",
+        "format_name": "Contact HM Revenue & Customs",
         "show_summaries": true
       },
       "routes": [


### PR DESCRIPTION
Good services are verbs. This makes the title consistent with the current breadcrumbs on the contact pages itself. Needed if we want to keep the breadcrumb the same after https://github.com/alphagov/government-frontend/pull/837.

Signed off by Ganesh.

https://trello.com/c/1LEofaHC