### PR TITLE
Remove no-op configuration option

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
`false` is the default value in Rails 5.0 / 5.1, and this option is no
longer supported in Rails 5.2.  Rails 5.2 has the same behaviour as
setting this to `false` in Rails 5.0 / 5.1.

For more, see https://blog.bigbinary.com/2016/02/13/rails-5-does-not-halt-callback-chain-when-false-is-returned.html