### PR TITLE
Remove code related to need_ids

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -26,7 +26,6 @@ class ContactPresenter
         { path: contact.link, type: "exact" }
       ],
       details: contact_details.merge(language: "en"),
-      need_ids: [],
       update_type: "major",
     }
   end

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -27,7 +27,6 @@ describe ContactPresenter do
       expect(payload[:rendering_app]).to eq("government-frontend")
       expect(payload[:routes].first[:path]).to eq(contact.link)
       expect(payload[:public_updated_at]).to be_present
-      expect(payload[:need_ids]).to be_empty
 
       details = payload[:details]
       expect(details[:description]).to eq(contact.description)


### PR DESCRIPTION
This field has been replaced by the `meets_user_needs` link type.