### PR TITLE
Improve DestroyAndRedirectContact

### DIFF
--- a/app/interactors/admin/destroy_and_redirect_contact.rb
+++ b/app/interactors/admin/destroy_and_redirect_contact.rb
@@ -9,18 +9,15 @@ module Admin
 
     def destroy_and_redirect
       contact.transaction do
-        # Overwrite with a redirect item in content-store
-        Publisher.publish(redirect_content_item_presenter)
+        Services.publishing_api.unpublish(
+          @contact.content_id,
+          type: 'redirect',
+          alternative_path: redirect_to_location
+        )
 
         # Remove from our database
         contact.destroy
       end
-    end
-
-  private
-
-    def redirect_content_item_presenter
-      ContactRedirectPresenter.new(contact, redirect_to_location)
     end
   end
 end

--- a/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
+++ b/spec/interactors/admin/destroy_and_redirect_contact_spec.rb
@@ -13,10 +13,12 @@ describe Admin::DestroyAndRedirectContact do
     end
 
     it "replaces the item in content store with a redirect item" do
-      presenter = ContactRedirectPresenter.new(contact, redirect_to_location)
-
-      expect(ContactRedirectPresenter).to receive(:new).with(contact, redirect_to_location).and_return(presenter)
-      expect(Publisher).to receive(:publish).with(presenter)
+      expect(Services.publishing_api).to receive(:unpublish)
+                                           .with(
+                                             contact.content_id,
+                                             type: 'redirect',
+                                             alternative_path: redirect_to_location
+                                           )
 
       subject.destroy_and_redirect
     end


### PR DESCRIPTION
Use the unpublish action in the Publishing API, rather than replacing
the content with a redirect.