### PR TITLE
Add more info field for webchat

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -76,6 +76,7 @@ private
       :contact_information,
       :title,
       :more_info_contact_form,
+      :more_info_webchat,
       :more_info_email_address,
       :more_info_post_address,
       :more_info_phone_number,

--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -61,6 +61,8 @@ private
       contact_form_links: ContactFormLinksPresenter.new(contact.contact_form_links).present,
       more_info_contact_form: govspeak(contact.more_info_contact_form),
 
+      more_info_webchat: govspeak(contact.more_info_webchat),
+
       email_addresses: EmailAddressesPresenter.new(contact.email_addresses).present,
       more_info_email_address: govspeak(contact.more_info_email_address),
 

--- a/app/tasks/import_contacts/contact_builder.rb
+++ b/app/tasks/import_contacts/contact_builder.rb
@@ -28,6 +28,7 @@ class ImportContacts
         post_addresses: post_address_records,
         phone_numbers: phone_number_records,
         more_info_contact_form: more_info_text_for(:contact_form),
+        more_info_webchat: attributes["more_info_webchat"],
         more_info_email_address: more_info_text_for(:email_address),
         more_info_post_address: more_info_text_for(:post_address),
         more_info_phone_number: more_info_text_for(:phone_number),

--- a/app/views/admin/contacts/_form.html.erb
+++ b/app/views/admin/contacts/_form.html.erb
@@ -11,6 +11,7 @@
       <%= f.input :description, as: :text, input_html: { rows: 8, class: 'input-md-8 form-control' } %>
       <%= f.input :before_you_contact_us, as: :text, label: 'Before you contact us', input_html: { rows: 5, class: 'input-md-8 form-control' }, hint: formatting_help_link %>
       <%= f.input :contact_information, as: :text, label: 'Information you will need', input_html: { rows: 5, class: 'input-md-8 form-control' }, hint: formatting_help_link %>
+      <%= f.input :more_info_webchat, as: :text, label: 'More information for webchat', input_html: { rows: 5, class: 'input-md-8 form-control' }, hint: formatting_help_link %>
       <%= f.input :query_response_time, as: :boolean, label: 'Show "When can I expect my reply" link' %>
       <%= f.input :popularity, class: 'input-md-3 form-control', hint: 'This is used to weight the contacts list, use call volume for example' %>
     </fieldset>

--- a/db/migrate/20180723102908_add_more_info_webchat_to_contacts.rb
+++ b/db/migrate/20180723102908_add_more_info_webchat_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddMoreInfoWebchatToContacts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contacts, :more_info_webchat, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160920172304) do
+ActiveRecord::Schema.define(version: 20180723102908) do
 
   create_table "contact_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "contact_group_type_id"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20160920172304) do
     t.integer  "popularity",                             default: 0
     t.integer  "organisation_id"
     t.string   "content_id",               limit: 36,                    null: false
+    t.text     "more_info_webchat",        limit: 65535
     t.index ["need_id"], name: "index_contacts_on_need_id", using: :btree
     t.index ["slug"], name: "index_contacts_on_slug", using: :btree
   end


### PR DESCRIPTION
This commit adds a more info field for the webchat section of a contact. This allows non-developers to change this text, which was previously hardcoded into government-frontend.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/798

Trello: https://trello.com/c/kcGo8LWv/331-webchats-changes-to-dynamic-text