### PR TITLE
Use standard healtcheck

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,0 @@
-class HealthcheckController < ActionController::API
-  def check
-    Contact.first # check DB connectivity
-    render json: { git_sha1: CURRENT_RELEASE_SHA }
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  get "healthcheck" => "healthcheck#check"
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+  )
 
   # Permanently redirect any requests for the root URL to /admin
   root :to => redirect("/admin", status: 301)


### PR DESCRIPTION
This uses the standard healthcheck endpoint from GovukAppConfig.

The hope is that this will prevent odd healthcheck errors in Sentry:

https://sentry.io/govuk/app-contacts-admin/issues/736044917

https://trello.com/c/CxGTjfcH