### PR TITLE
Revert "Bump gds-api-adapters from 53.2.0 to 54.1.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "simple_form", "~> 4.0.1"
 gem "virtus", "~> 1.0.5"
 gem "whenever", "~> 0.10.0"
 
-gem 'gds-api-adapters', "~> 54.1"
+gem 'gds-api-adapters', "~> 53.2"
 gem "gds-sso", "~> 13.6.0"
 gem "govspeak", "~> 5.6.0"
 gem 'govuk_admin_template', '6.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     ffi (1.9.25)
     friendly_id (5.2.3)
       activerecord (>= 4.0.0)
-    gds-api-adapters (54.1.2)
+    gds-api-adapters (53.2.0)
       addressable
       link_header
       null_logger
@@ -410,7 +410,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.11)
   fakefs (= 0.18.0)
   friendly_id (= 5.2.3)
-  gds-api-adapters (~> 54.1)
+  gds-api-adapters (~> 53.2)
   gds-sso (~> 13.6.0)
   govspeak (~> 5.6.0)
   govuk-content-schema-test-helpers (= 1.6.1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-contacts-admin")
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_APP_PARAM", "CONTACTS_ADMIN_COMMITISH")
   govuk.buildProject(
     publishingE2ETests: true,
     rubyLintDiff: false,

--- a/app/tasks/import_organisations.rb
+++ b/app/tasks/import_organisations.rb
@@ -15,7 +15,7 @@ class ImportOrganisations
 private
 
   def organisations
-    base_uri = Plek.new.website_root
+    base_uri = Plek.new.find('whitehall-admin')
     GdsApi::Organisations.new(base_uri).organisations.with_subsequent_pages
   end
 


### PR DESCRIPTION
Another attempt to get e2e-tests working again since https://github.com/alphagov/contacts-admin/pull/498 didn't do the job.


/cc @theseanything @cbaines 