### PR TITLE
Fix the running of the E2E tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-contacts-admin")
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_APP_PARAM", "CONTACTS_ADMIN_COMMITISH")
   govuk.buildProject(
     publishingE2ETests: true,
     rubyLintDiff: false,


### PR DESCRIPTION
Previously, the deployed-to-production branch of contacts-admin was
being used for the test, as the repository name/job name is used to
determine what to specify the commit for testing.

This change means that the Publishing E2E tests will actually run with
the version of contacts-admin we're looking to test.

This was noticed as this commit here [1] actually broke the Publishing
E2E tests, but it wasn't noticed before merging.

1: 25408e7045ddb1bb354dc1c1864b3d8ebaffe9d5