### PR TITLE
Present primary publishing organisation

### DIFF
--- a/app/interactors/admin/create_contact.rb
+++ b/app/interactors/admin/create_contact.rb
@@ -20,7 +20,10 @@ module Admin
     def send_links_to_publishing_api
       Publisher.client.patch_links(
         contact.content_id,
-        links: { organisations: [contact.organisation.content_id] }
+        links: {
+          organisations: [contact.organisation.content_id],
+          primary_publishing_organisation: [contact.organisation.content_id]
+        }
       )
     end
   end

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -63,4 +63,21 @@ namespace :contacts do
       ).redirect_gone_contact
     end
   end
+
+  desc "Patch links for all contacts with primary_publishing_organisation"
+  task patch_links_with_primary_publishing_organisation: :environment do
+    count = Contact.count
+    puts "Patching links for #{count} contacts with primary_publishing_organisation"
+    Contact.all.each_with_index do |contact, i|
+      Publisher.client.patch_links(
+        contact.content_id,
+        links: {
+          organisations: [contact.organisation.content_id],
+          primary_publishing_organisation: [contact.organisation.content_id]
+        }
+      )
+      puts "Processing #{i}-#{i + 99} of #{count} contacts" if (i % 100).zero?
+    end
+    puts "Finished patching links for contacts with primary_publishing_organisation"
+  end
 end

--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -36,7 +36,10 @@ feature "Contact creation", auth: :user do
 
     assert_publishing_api_patch_links(
       created_contact.content_id,
-      links: { organisations: [contact_organisation.content_id] }
+      links: {
+        organisations: [contact_organisation.content_id],
+        primary_publishing_organisation: [contact_organisation.content_id]
+      }
     )
   end
 end


### PR DESCRIPTION
At present only `organisations` are sent to the publishing-api
(via patch_links) when a contact is published.

This commit also includes `primary_publishing_organisation` in the payload sent 
to `publishing-api`.

We need this information to be available in the `content-data-api`
so we can filter based on it.

Trello: https://trello.com/c/Vsdvr5vb/1390-add-primary-org-to-contacts