### PR TITLE
Run rspec as the default Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,13 @@
 require File.expand_path('../config/application', __FILE__)
 
 Contacts::Application.load_tasks
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+rescue LoadError
+  # no rspec available
+end


### PR DESCRIPTION
The README suggests this is the case, but it isn't. This commit
changes that!