### PR TITLE
Avoid a Capybara deprecation warning

### DIFF
--- a/spec/features/admin/contact_create_spec.rb
+++ b/spec/features/admin/contact_create_spec.rb
@@ -18,8 +18,8 @@ feature "Contact creation", auth: :user do
         description: contact[:description],
         contact_information: contact[:contact_information]
       ) do
-        select contact_organisation, from: "contact_organisation_id"
-        select contact_group, from: "contact_contact_group_ids"
+        select contact_organisation.to_s, from: "contact_organisation_id"
+        select contact_group.to_s, from: "contact_contact_group_ids"
       end
     }.to change { Contact.count }.by(1)
   end
@@ -29,7 +29,7 @@ feature "Contact creation", auth: :user do
       title: contact[:title],
       description: contact[:description],
     ) do
-      select contact_organisation, from: "contact_organisation_id"
+      select contact_organisation.to_s, from: "contact_organisation_id"
     end
 
     created_contact = Contact.last

--- a/spec/features/admin/contact_edit_spec.rb
+++ b/spec/features/admin/contact_edit_spec.rb
@@ -15,7 +15,7 @@ feature "Contact editing", auth: :user do
       quick_link_title_1: "GOV.UK",
       popularity: 2
     ) do
-      select contact_group, from: "contact_contact_group_ids"
+      select contact_group.to_s, from: "contact_contact_group_ids"
     end
 
     verify contact_updated(


### PR DESCRIPTION
Change to using strings, rather than objects with the select function.

This avoids deprecation warnings like:

Locator ContactGroup:#<ContactGroup id: 212, contact_group_type_id:
13, title: "new contact type", description: "contact group description
12", contacts_count: nil, created_at: "2019-07-09 10:06:24",
updated_at: "2019-07-09 10:06:24", slug: "new-contact-type",
organisation_id: 494> for selector :option must be an instance of
String or Symbol. This will raise an error in a future version of
Capybara.