### PR TITLE
Update gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'plek', '~> 3'
 gem 'govuk_frontend_toolkit', '~> 8'
 gem 'sass-rails', '~> 6'
 gem 'select2-rails', '~> 4'
-gem 'therubyracer', '~> 0.12', platforms: :ruby
 gem 'uglifier', '~> 4'
 
 # development

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'simple_form', '~> 4'
 gem 'virtus', '~> 1'
 gem 'whenever', '~> 1.0'
 
-gem 'gds-api-adapters', '~> 53'
+gem 'gds-api-adapters', '~> 60'
 gem 'gds-sso', '~> 14'
 gem 'govspeak', '~> 6'
 gem 'govuk_admin_template', '~> 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     ffi (1.11.1)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
-    gds-api-adapters (53.2.0)
+    gds-api-adapters (60.0.0)
       addressable
       link_header
       null_logger
@@ -200,9 +200,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -430,7 +430,7 @@ DEPENDENCIES
   factory_bot_rails (~> 5)
   fakefs (~> 0.20)
   friendly_id (~> 5)
-  gds-api-adapters (~> 53)
+  gds-api-adapters (~> 60)
   gds-sso (~> 14)
   govspeak (~> 6)
   govuk-content-schema-test-helpers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,6 @@ GEM
     jwt (2.2.1)
     kgio (2.11.2)
     kramdown (1.15.0)
-    libv8 (3.16.14.19)
     link_header (0.0.8)
     logstash-event (1.2.02)
     logstasher (1.3.0)
@@ -286,7 +285,6 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.0)
-    ref (2.0.0)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -375,9 +373,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -454,7 +449,6 @@ DEPENDENCIES
   simple_form (~> 4)
   simplecov (~> 0.17)
   simplecov-rcov (~> 0.2)
-  therubyracer (~> 0.12)
   thin
   uglifier (~> 4)
   virtus (~> 1)

--- a/app/tasks/import_organisations.rb
+++ b/app/tasks/import_organisations.rb
@@ -15,7 +15,7 @@ class ImportOrganisations
 private
 
   def organisations
-    base_uri = Plek.new.find('whitehall-admin')
+    base_uri = Plek.new.website_root
     GdsApi::Organisations.new(base_uri).organisations.with_subsequent_pages
   end
 


### PR DESCRIPTION
Replaces https://github.com/alphagov/contacts-admin/pull/509.

[Trello Card](https://trello.com/c/bKqmj0sG/1274-8-merge-gds-api-adapter-bump-in-contacts-admin)