### PR TITLE
Set assets.export_concurrent to false

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,6 +3,9 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "1.0"
 
+# TODO: This seems to help work around asset precompilation failures
+Rails.application.config.assets.export_concurrent = false
+
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
 


### PR DESCRIPTION
There seems to be issues with Sprockets version 4, errors like [1]
occur when precompiling assets.

A suggestion I've seen to avoid this is to add this configuration [2].

1: SassC::SyntaxError: Error: error in C function font-path: undefined
method `[]' for nil:NilClass
2: https://github.com/rails/sprockets/issues/581#issuecomment-486984663