### PR TITLE
Change sassc to 2.2.1 in the Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.1.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
This might help with some issues we're having with sassc since the
Sprockets 4 update. Note that I've had problems builing the native
extensions with gcc > 4.