### PR TITLE
Fix hardcoded HMRC organisation used for all contacts

### DIFF
--- a/app/presenters/contact_presenter.rb
+++ b/app/presenters/contact_presenter.rb
@@ -41,7 +41,7 @@ class ContactPresenter
     {
       links: {
         "related" => @contact.related_contacts.pluck(:content_id),
-        "parent"  => [PublishFinders::HMRC_CONTACTS_CONTENT_ID],
+        "parent"  => [parent_content_id],
       },
     }
   end
@@ -49,6 +49,14 @@ class ContactPresenter
   alias_method :payload, :present
 
 private
+
+  def parent_content_id
+    if contact.organisation.content_id == PublishFinders::HMRC_ORGANISATION_CONTENT_ID
+      PublishFinders::HMRC_CONTACTS_CONTENT_ID
+    else
+      contact.organisation.content_id
+    end
+  end
 
   def contact_details
     {

--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -2,6 +2,7 @@
 # only contains contacts related to HMRC.
 class PublishFinders
   HMRC_CONTACTS_CONTENT_ID = "b110c03c-3f8d-4327-906b-17ebd872e6a6".freeze
+  HMRC_ORGANISATION_CONTENT_ID = "6667cce2-e809-4e21-ae09-cb0bdc1ddda3".freeze
 
   def self.call
     new.call

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -54,5 +54,8 @@ FactoryBot.define do
         contact.email_addresses << FactoryBot.create(:email_address, contact_id: contact.id)
       end
     end
+    trait :for_hmrc do
+      association :organisation, :for_hmrc
+    end
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -10,4 +10,11 @@ FactoryBot.define do
     content_id { |_n| SecureRandom.uuid }
     contact_index_content_id { SecureRandom.uuid }
   end
+
+  trait :for_hmrc do
+    title { "HM Revenues & Customs" }
+    abbreviation { "HMRC" }
+    content_id { "6667cce2-e809-4e21-ae09-cb0bdc1ddda3" }
+    contact_index_content_id { "b110c03c-3f8d-4327-906b-17ebd872e6a6" }
+  end
 end


### PR DESCRIPTION
Previously it was assumed that HMRC would be the only organisation for which contacts would be published for. When a new contact was created, links sent to the publishing API contained hardcoded references to HMRC's contacts finder. 

This PR changes the parent link to be the contacts organisations id, unless it is HMRC then it remains as the HMRC contacts finder. 

This is needed to publish an non-HMRC contact page, (relating to the web chat work.)