### PR TITLE
Replace `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,15 @@
+inherit_gem:
+  rubocop-govuk:
+    - "config/default.yml"
+
 AllCops:
   TargetRubyVersion: 2.3
+
+Metrics/BlockLength:
+  Exclude:
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
+    - "config/routes.rb"
+    - "config/initializers/*.rb"
+    - "config/environments/*.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,8 @@ end
 # testing
 group :test do
   gem "govuk-content-schema-test-helpers"
-  gem "govuk-lint"
+  gem "rubocop-govuk", "~> 1"
+  gem "scss_lint-govuk", "~> 0"
 
   gem "capybara", "~> 3"
   gem "factory_bot_rails", "~> 5"

--- a/Gemfile
+++ b/Gemfile
@@ -1,56 +1,56 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 5.2'
+gem "rails", "~> 5.2"
 
-gem 'active_hash', '~> 3'
-gem 'ancestry', '~> 3'
-gem 'bootsnap', '~> 1'
-gem 'friendly_id', '~> 5'
-gem 'mlanett-redis-lock', '~> 0.2'
-gem 'mysql2', '~> 0.4'
-gem 'paper_trail', '~> 10'
-gem 'searchlight', '~> 4'
-gem 'simple_form', '~> 5'
-gem 'virtus', '~> 1'
-gem 'whenever', '~> 1.0'
+gem "active_hash", "~> 3"
+gem "ancestry", "~> 3"
+gem "bootsnap", "~> 1"
+gem "friendly_id", "~> 5"
+gem "mlanett-redis-lock", "~> 0.2"
+gem "mysql2", "~> 0.4"
+gem "paper_trail", "~> 10"
+gem "searchlight", "~> 4"
+gem "simple_form", "~> 5"
+gem "virtus", "~> 1"
+gem "whenever", "~> 1.0"
 
-gem 'gds-api-adapters', '~> 61'
-gem 'gds-sso', '~> 14'
-gem 'govspeak', '~> 6'
-gem 'govuk_admin_template', '~> 6'
-gem 'govuk_app_config', '~> 2'
-gem 'plek', '~> 3'
+gem "gds-api-adapters", "~> 61"
+gem "gds-sso", "~> 14"
+gem "govspeak", "~> 6"
+gem "govuk_admin_template", "~> 6"
+gem "govuk_app_config", "~> 2"
+gem "plek", "~> 3"
 
 # assets
-gem 'govuk_frontend_toolkit', '~> 8'
-gem 'sass-rails', '~> 6'
-gem 'select2-rails', '~> 4'
-gem 'uglifier', '~> 4'
+gem "govuk_frontend_toolkit", "~> 8"
+gem "sass-rails", "~> 6"
+gem "select2-rails", "~> 4"
+gem "uglifier", "~> 4"
 
 # development
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
-  gem 'railroady'
-  gem 'thin'
+  gem "better_errors"
+  gem "binding_of_caller"
+  gem "railroady"
+  gem "thin"
 end
 
 group :development, :test do
-  gem 'pry-rails'
+  gem "pry-rails"
 end
 
 # testing
 group :test do
-  gem 'govuk-content-schema-test-helpers'
-  gem 'govuk-lint'
+  gem "govuk-content-schema-test-helpers"
+  gem "govuk-lint"
 
-  gem 'capybara', '~> 3'
-  gem 'factory_bot_rails', '~> 5'
-  gem 'fakefs', '~> 0.20', require: 'fakefs/safe'
-  gem 'json-schema', '~> 2'
-  gem 'rspec-rails', '~> 3'
-  gem 'shoulda-matchers', '~> 4'
-  gem 'simplecov', '~> 0.17'
-  gem 'simplecov-rcov', '~> 0.2'
-  gem 'webmock', '~> 3'
+  gem "capybara", "~> 3"
+  gem "factory_bot_rails", "~> 5"
+  gem "fakefs", "~> 0.20", require: "fakefs/safe"
+  gem "json-schema", "~> 2"
+  gem "rspec-rails", "~> 3"
+  gem "shoulda-matchers", "~> 4"
+  gem "simplecov", "~> 0.17"
+  gem "simplecov-rcov", "~> 0.2"
+  gem "webmock", "~> 3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,11 +137,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -238,7 +233,7 @@ GEM
     paper_trail (10.3.1)
       activerecord (>= 4.2)
       request_store (~> 1.1)
-    parallel (1.18.0)
+    parallel (1.19.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     plek (3.0.0)
@@ -319,6 +314,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -347,6 +346,8 @@ GEM
       tilt
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     searchlight (4.1.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
@@ -428,7 +429,6 @@ DEPENDENCIES
   gds-sso (~> 14)
   govspeak (~> 6)
   govuk-content-schema-test-helpers
-  govuk-lint
   govuk_admin_template (~> 6)
   govuk_app_config (~> 2)
   govuk_frontend_toolkit (~> 8)
@@ -441,7 +441,9 @@ DEPENDENCIES
   railroady
   rails (~> 5.2)
   rspec-rails (~> 3)
+  rubocop-govuk (~> 1)
   sass-rails (~> 6)
+  scss_lint-govuk (~> 0)
   searchlight (~> 4)
   select2-rails (~> 4)
   shoulda-matchers (~> 4)

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,9 +13,9 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
@@ -26,11 +26,11 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,16 +13,16 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint with similar params to CI"
+desc "Run rubocop with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --format clang app bin config Gemfile lib spec"
+  sh "bundle exec rubocop --format clang app config Gemfile lib spec"
 end


### PR DESCRIPTION
- Fixes existing linting issues
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk