### PR TITLE
Fix deployment errors due to rubocop rake task

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,9 @@
-desc "Run rubocop with similar params to CI"
-task "lint" do
-  sh "bundle exec rubocop --format clang app config Gemfile lib spec"
+unless Rails.env.production?
+  require "rubocop/rake_task"
+
+  RuboCop::RakeTask.new(:lint) do |t|
+    t.patterns = %w(app config Gemfile lib spec)
+    t.formatters = %w(clang)
+    t.options = %w(--parallel)
+  end
 end


### PR DESCRIPTION
Rubocop cannot run in production.  Prior art:
 - https://github.com/alphagov/travel-advice-publisher/pull/755/commits/1f94be85f9eb8116034e7042b214a9384de0d5ff
 - https://github.com/alphagov/asset-manager/commit/a7ff35d2210575dace952bd686d7eda11c8b44f3

Also flipped to the new style of task declaration as it seems nicer.