### PR TITLE
Use delete_all method to remove contact relationships

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -21,7 +21,7 @@ class Contact < ApplicationRecord
   has_many :email_addresses, inverse_of: :contact, dependent: :destroy
   has_many :post_addresses, inverse_of: :contact, dependent: :destroy
 
-  has_many :contact_relationships, dependent: :destroy
+  has_many :contact_relationships, dependent: :delete_all
   has_many :related_contacts, through: :contact_relationships
 
   validates :title, presence: true


### PR DESCRIPTION
The `destroy` method fails with
```
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 
'contact_relationships.' in 'where clause': DELETE FROM `contact_relationships` 
WHERE `contact_relationships`.`` IS NULL
```
This is because contact_relationships table doesn't have a primary key.
When we use `dependent: :destroy` rails tries to instantiate each dependent model which is impossible without a primary key. 

We should to use `dependent: :delete_all` so rails doesn't initialise any dependent models.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3867768

---

Tested in integration:

<img width="530" alt="contact-test" src="https://user-images.githubusercontent.com/38078064/70343017-22e26700-184e-11ea-8249-0be5e9132c97.png">
