### PR TITLE
[DO NOT MERGE BEFORE alphagov/govuk-puppet#10054] Access Worldwide API via whitehall-frontend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     ffi (1.11.3)
     friendly_id (5.3.0)
       activerecord (>= 4.0.0)
-    gds-api-adapters (63.2.0)
+    gds-api-adapters (63.3.0)
       addressable
       link_header
       null_logger
@@ -256,7 +256,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.3)
-    rack (2.0.8)
+    rack (2.1.1)
     rack-cache (1.11.0)
       rack (>= 0.4)
     rack-test (1.1.0)

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,9 +1,9 @@
-require "gds_api/worldwide"
+require "gds_api"
 require "gds_api/publishing_api_v2"
 
 module Services
   def self.worldwide_api
-    @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find("whitehall-admin"))
+    @worldwide_api ||= GdsApi.worldwide
   end
 
   def self.publishing_api


### PR DESCRIPTION
To simplify the migration of Whitehall to AWS, calls to the Worldwide
API should be directed to whitehall-frontend, not whitehall-admin.

Co-authored-by: Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk>