### PR TITLE
[DO NOT MERGE] Disable contacts-admin cron job for migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,9 @@ inherit_gem:
     - "config/default.yml"
     - "config/rails.yml"
 
-AllCops:
-  TargetRubyVersion: 2.3
+inherit_mode:
+  merge:
+    - Exclude
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-govuk (3.1.0)
+    rubocop-govuk (3.3.0)
       rubocop (= 0.80.1)
       rubocop-rails (~> 2)
       rubocop-rspec (~> 1.28)
@@ -473,4 +473,4 @@ DEPENDENCIES
   whenever (~> 1.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,16 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path("config/application", __dir__)
 
 Contacts::Application.load_tasks
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
 
   RSpec::Core::RakeTask.new(:spec)
 
-  task :default => :spec
-rescue LoadError
+  task default: :spec
+rescue LoadError # rubocop:disable Lint/SuppressedException
   # no rspec available
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,6 +6,6 @@ job_type :rake, "cd :path && govuk_setenv contacts bundle exec rake :task :outpu
 
 set :output, error: "log/cron.error.log", standard: "log/cron.log"
 
-every :day, at: "3am" do
-  rake "organisations:import"
-end
+# every :day, at: "3am" do
+#   rake "organisations:import"
+# end


### PR DESCRIPTION
* Disables cron job which triggers the `organisations:import` rake task.

* These changes will automatically update the `deploy` user crontab when the application is deployed using Jenkins.

* `organisations:import` rake task runs nightly at 3AM and imports a list of organisations from `/government/organisations/` API.

* Note: this cron job is configured using the `whenever` gem and **not** Puppet.