### PR TITLE
Extend 'default' task with RuboCop linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,12 +9,4 @@ inherit_mode:
 
 Metrics/BlockLength:
   Exclude:
-    - "Rakefile"
-    - "**/*.rake"
-    - "spec/**/*.rb"
     - "config/routes.rb"
-    - "config/initializers/*.rb"
-    - "config/environments/*.rb"
-
-Rails/OutputSafety:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ end
 
 group :development, :test do
   gem "pry-rails"
+  gem "rspec-rails", "~> 4"
 end
 
 # testing
@@ -49,7 +50,6 @@ group :test do
   gem "factory_bot_rails", "~> 5"
   gem "fakefs", "~> 1.2", require: "fakefs/safe"
   gem "json-schema", "~> 2"
-  gem "rspec-rails", "~> 4"
   gem "shoulda-matchers", "~> 4"
   gem "simplecov", "~> 0.18"
   gem "simplecov-rcov", "~> 0.2"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
 require File.expand_path("config/application", __dir__)
-
 Rails.application.load_tasks
+
+# RSpec shoves itself into the default task without asking, which confuses the ordering.
+# https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
+Rake::Task[:default].clear unless Rails.env.production?
+task default: %i[spec lint]

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,4 @@
 
 require File.expand_path("config/application", __dir__)
 
-Contacts::Application.load_tasks
-
-begin
-  require "rspec/core/rake_task"
-
-  RSpec::Core::RakeTask.new(:spec)
-
-  task default: :spec
-rescue LoadError
-  # no rspec available
-end
+Rails.application.load_tasks

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
 
   def govspeak(text)
     if text
-      content_tag(:div, Govspeak::Document.new(text).to_html.html_safe, class: "govspeak")
+      content_tag(:div, Govspeak::Document.new(text).to_html.html_safe, class: "govspeak") # rubocop:disable Rails/OutputSafety
     end
   end
 

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,4 +1,4 @@
-# Use this setup block to configure all options available in SimpleForm.
+# rubocop:disable Metrics/BlockLength
 SimpleForm.setup do |config|
   config.wrappers :bootstrap, tag: "div", class: "form-group", error_class: "error" do |b|
     b.use :html5
@@ -43,3 +43,4 @@ SimpleForm.setup do |config|
   # buttons and other elements.
   config.default_wrapper = :bootstrap
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,9 +1,4 @@
-unless Rails.env.production?
-  require "rubocop/rake_task"
-
-  RuboCop::RakeTask.new(:lint) do |t|
-    t.patterns = %w[app config Gemfile lib spec]
-    t.formatters = %w[clang]
-    t.options = %w[--parallel]
-  end
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
 end


### PR DESCRIPTION
https://trello.com/c/5Gob6WUL/147-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This adds a new 'lint' rake task that runs as part of a default call to
'rake'. Having linting run locally by default makes it easier to catch
build issues, and is a prerequisite for moving to GitHub Actions, since we
want to avoid listing lots of separate build steps.