### PR TITLE
Always print coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,5 @@ group :test do
   gem "json-schema"
   gem "shoulda-matchers"
   gem "simplecov"
-  gem "simplecov-rcov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,8 +378,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -465,7 +463,6 @@ DEPENDENCIES
   shoulda-matchers
   simple_form
   simplecov
-  simplecov-rcov
   thin
   uglifier
   virtus

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,5 @@
 require "simplecov"
-require "simplecov-rcov"
-
 SimpleCov.start "rails"
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 
 ENV["RAILS_ENV"] ||= "test"
 


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that RCov is just an optional formatter. We can still see a
detailed webpage of coverage without it.