### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
-    friendly_id (5.3.0)
+    friendly_id (5.4.0)
       activerecord (>= 4.0.0)
     gds-api-adapters (67.0.1)
       addressable

--- a/app/tasks/import_contacts.rb
+++ b/app/tasks/import_contacts.rb
@@ -20,7 +20,7 @@ class ImportContacts
 
     logger.info "Importing: Import_id, title"
 
-    CSV.foreach(@file_path, csv_opts)  do |entry_row|
+    CSV.foreach(@file_path, **csv_opts) do |entry_row|
       hash = entry_row.to_hash
       contact = builder.build(hash)
 


### PR DESCRIPTION
These are the changes necessary for Ruby 2.7.1

There is a script that can be run to update all app Ruby versions at once, so leaving the Ruby version as 2.6.6 in this PR. 