### PR TITLE
Add filter to content item for HM Revenue & Customs

### DIFF
--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -49,6 +49,7 @@ private
         ],
         "filter": {
           "format": "contact",
+          "organisations": %w[hm-revenue-customs],
         },
         "format_name": "Contact HM Revenue & Customs",
         "show_summaries": true,


### PR DESCRIPTION
We are currently building a Search API query based on the content of the `filter` hash within the content item when fetching contact details.

However we aren't filtering by organisation, so all organisation results are being returned on the HMRC contact page, rather than only their own.

This can be tested by changing the Search API query, e.g.
https://www.gov.uk/api/search.json?filter_format=contact (141 results, which include two HM Passport Office contacts)
https://www.gov.uk/api/search.json?filter_format=contact&filter_organisations=hm-revenue-customs (139 results, which does not include the HMPO contacts)

After merging, the content item will need updating using `rake finders:publish`.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4408921