### PR TITLE
Remove need for REDIS_HOST and REDIS_PORT env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,21 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV DATABASE_URL mysql2://root:root@mysql/contacts-admin
 ENV GOVUK_APP_NAME contacts-admin
 ENV PORT 3051
-ENV RAILS_ENV development
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* .ruby-version $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile

--- a/app/lib/contacts/distributed_lock.rb
+++ b/app/lib/contacts/distributed_lock.rb
@@ -10,25 +10,12 @@ module Contacts
     end
 
     def lock
-      redis.lock("contacts-admin:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
+      Redis.current.lock("contacts-admin:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
         Rails.logger.debug("Successfully got a lock. Running...")
         yield
       end
     rescue Redis::Lock::LockNotAcquired => e
       Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
-    end
-
-  private
-
-    def redis
-      @redis ||= begin
-        redis_config = {
-          host: ENV["REDIS_HOST"] || "127.0.0.1",
-          port: ENV["REDIS_PORT"] || 6379,
-        }
-
-        Redis.new(redis_config)
-      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This is one of the few GOV.UK projects that uses this old approach to
configuring Redis - whereas most of the other ones use the approach
supported natively by the Redis gem [1] of using REDIS_URL. Removing
this will allow us to remove the need for REDIS_HOST and REDIS_PORT env
vars in our architecture and also allows this code to be simplified.

[1]: https://github.com/redis/redis-rb