### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,9 @@ node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_APP_PARAM", "CONTACTS_ADMIN_COMMITISH")
   govuk.buildProject(
     publishingE2ETests: true,
-    sassLint: false,
     repoName: 'contacts-admin',
     beforeTest: {
       govuk.setEnvar('RUNNING_IN_CI', 'true')
-      sh("yarn install")
     },
     brakeman: true,
   )


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82