### PR TITLE
Remove unused Rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,27 +90,19 @@ bundle exec rake db:seed
 bundle exec rake contacts:import_hmrc DATA_FILE=db/contact-records.csv
 ```
 
-## Redirecting removed contacts
+## Redirecting contacts that have been removed already
 
-The Web UI of the app issues a “gone” item to the publishing api when a contact is deleted. Sometimes the correct thing to do is to issue a “redirect” instead. There is no web UI for this but there are two rake tasks to achieve this depending on the state of the contact to be redirected.
+Contacts Admin used to issue a “gone” item to Publishing API when a contact was deleted. But since [#838](https://github.com/alphagov/contacts-admin/pull/838), we issue a “redirect” instead.
 
-### For contacts that still exist
+If a contact was removed as a “gone” item and now needs to be redirected, we have a Rake task for this:
 
-The rake task is `contacts:remove_with_redirect`, and is invoked as follows:
-```
-$ cd /var/apps/contacts
-$ sudo -u deploy govuk_setenv contacts bundle exec rake contacts:remove_with_redirect[contact-to-remove-slug,path-to-redirect-to]
-```
-
-### For contacts that have been removed already
-
-The rake task is `contacts:replace_gone_with_redirect`, and is invoked as follows:
 ```
 $ cd /var/apps/contacts
 $ sudo -u deploy govuk_setenv contacts bundle exec rake contacts:replace_gone_with_redirect[removed-contact-slug,organisation-slug,path-to-redirect-to]
 ```
 
-This will fail if any of the following are true
+This will fail if either of the following are true:
+
 1. `removed-contact-slug` references a contact object in the Contacts Admin database
 2. the path constructed by `removed-contact-slug` and `organisation-slug` does not refer to a “gone” item in content store
 

--- a/lib/tasks/contacts.rake
+++ b/lib/tasks/contacts.rake
@@ -33,25 +33,6 @@ namespace :contacts do
     Contact.find_each(&:republish)
   end
 
-  desc "Remove a contact and redirect it"
-  task :remove_with_redirect, %i[contact_slug redirect_to_location] => :environment do |_task, args|
-    if args.contact_slug.blank? || args.redirect_to_location.blank?
-      puts "Usage: rake contacts:remove_with_redirect[contact-to-remove-slug,path-to-redirect-to]"
-    else
-      contact = Contact.find_by(slug: args.contact_slug)
-      if contact.nil?
-        puts "Contact #{args.contact_slug} doesn't exist, consider using rake contacts:replace_gone_with_redirect"
-      else
-        print "Contact #{contact.link} removed with redirect to #{args.redirect_to_location} "
-        if Admin::DestroyAndRedirectContact.new(contact, args.redirect_to_location).destroy_and_redirect
-          puts "SUCCESS"
-        else
-          puts "ERROR"
-        end
-      end
-    end
-  end
-
   desc "Put in place a redirect for an already removed contact"
   task :replace_gone_with_redirect, %i[gone_content_id redirect_to_location] => :environment do |_task, args|
     if args.gone_content_id.blank? || args.redirect_to_location.blank?


### PR DESCRIPTION
This is now the default behaviour as of #838, so should never have to be invoked by a developer again.