### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,11 @@ Rails.application.routes.draw do
         GovukHealthcheck::ActiveRecord,
       )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+  )
+
   # Permanently redirect any requests for the root URL to /admin
   root to: redirect("/admin", status: 301)
 


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)