### PR TITLE
Fix polymorphic path bug

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -72,7 +72,7 @@ private
 
   def successful_update_url
     if params[:tab].present?
-      [:admin, @contact, params[:tab]]
+      [:admin, @contact, params[:tab].to_sym]
     else
       [:edit, :admin, @contact]
     end


### PR DESCRIPTION
This polymorphic route was generating an error due to the tab param
being a sting `Please use symbols for polymorphic route arguments.`.

I've also had a gander at the rest of the app and didn't spot any more
occurrences of strings in these route types.

Sentry error: https://sentry.io/organizations/govuk/issues/2501896125/?project=202215&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox 

As reported by a Zendesk user: https://govuk.zendesk.com/agent/tickets/4607154