### PR TITLE
Fix Contacts test

### DIFF
--- a/spec/models/post_address_spec.rb
+++ b/spec/models/post_address_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe PostAddress, type: :model do
+  setup do
+    stub_world_location_api
+  end
+
   let(:item) { create(:post_address) }
   it_behaves_like "an associated data model"
   it_behaves_like "a versioned data model"

--- a/spec/presenters/post_addresses_presenter_spec.rb
+++ b/spec/presenters/post_addresses_presenter_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
-require "gds_api/test_helpers/worldwide"
 
 describe PostAddressesPresenter do
-  include GdsApi::TestHelpers::Worldwide
   let(:post) { create :post_address, description: "post description" }
 
   it "transforms a contact to the correct format" do
-    stub_worldwide_api_has_location(post.world_location_slug)
+    stub_world_location_api
 
     presented = PostAddressesPresenter.new([post]).present.first
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,3 +34,8 @@ RSpec.configure do |config|
   config.include FeaturesHelpers, type: :feature
   config.include FileCreationHelper
 end
+
+def stub_world_location_api
+  stub_request(:get, "#{Plek.new.website_root}/api/world-locations/united-kingdom")
+    .to_return(status: 200, body: "{}")
+end


### PR DESCRIPTION
We're intermittently - but regularly - seeing the following tests
fail:

```
rspec ./spec/models/post_address_spec.rb:5 # PostAddress behaves like an associated data model registers its parent contact on save
rspec ./spec/presenters/post_addresses_presenter_spec.rb:8 # PostAddressesPresenter transforms a contact to the correct format
```

They both have the same error:

```
    Failure/Error:
      Services
        .worldwide_api
        .world_location(location_slug)
        .parsed_content

    WebMock::NetConnectNotAllowedError:
      Real HTTP connections are disabled. Unregistered request: GET http://www.dev.gov.uk/api/world-locations/united-kingdom with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'www.dev.gov.uk', 'User-Agent'=>'gds-api-adapters/71.5.0 ()'}

      You can stub this request with the following snippet:

      stub_request(:get, "http://www.dev.gov.uk/api/world-locations/united-kingdom").
        with(
          headers: {
      	  'Accept'=>'application/json',
      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
      	  'Host'=>'www.dev.gov.uk',
      	  'User-Agent'=>'gds-api-adapters/71.5.0 ()'
          }).
          to_return(status: 200, body: "", headers: {})

      registered request stubs:

      stub_request(:any, "/\Ahttp:\/\/publishing-api.dev.gov.uk/")
      stub_request(:patch, "/\Ahttp:\/\/publishing-api.dev.gov.uk\/v2\/links\//")
      stub_request(:put, "/\Ahttp:\/\/publishing-api.dev.gov.uk\/v2\/content\//")
```

I was able to reproduce this locally with a clean `make` in
govuk-docker. Oddly, when I attempted to find the culprit commit
with `git bisect`, I couldn't reproduce the issue, even when I
eventually went back to the clean `main`.

The `stub_worldwide_api_has_location` method
[provided by gds-api-adapters](https://github.com/alphagov/gds-api-adapters/blob/c2944f00b8de45b5c78b195807c055367da71630/lib/gds_api/test_helpers/worldwide.rb#L92-L96)
doesn't appear to be stubbing correctly. I did wonder if it might
be something to do with the setting of
[`WORLDWIDE_API_ENDPOINT`](https://github.com/alphagov/gds-api-adapters/blob/c2944f00b8de45b5c78b195807c055367da71630/lib/gds_api/test_helpers/worldwide.rb#L9),
but if that were the case, I'd expect to see `/api/world-locations`
with some prefix in the "registered request stubs" output above,
so it's more like the stub isn't being called, or is being reset,
prior to running the test.

The only other repo that uses this stub method is smart-answers:
https://github.com/search?q=org%3Aalphagov+stub_worldwide_api_has_location&type=code

I can't see any difference between smart-answers and contacts-admin
that would explain why the stubbing works in the former and not
the latter.

In desperation, I've removed the call to GDS API Adapters, and
simply stubbed the response myself. The value of the response
seems irrelevant, it only matters that it's JSON (in this case,
"{}"). For that reason, it doesn't seem a terrible thing to stop
using the stubbing method from gds-api-adapters, as the duplication
is minimal and it seems the dependency is only ephemeral in practice.