### PR TITLE
Upgrade CI to use MySQL 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,4 +13,6 @@ node {
     },
     brakeman: true,
   )
+  // Run against the MySQL 8 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/contacts_test")
 }


### PR DESCRIPTION
This changes the Jenkins CI configuration to use MySQL 8.

MySQL is [available at port `33068 `](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use) on the CI server. By explicitly setting the `TEST_DATABASE_URL`, we're telling Rails to use that MySQL server.

Previously, Rails implicitly used the default MySQL port `3306` which is a MySQL 5.5 server.

Trello ticket: https://trello.com/c/btcm7JyB/

The database config is already using the correct ENV var 

![image](https://user-images.githubusercontent.com/42515961/144841589-cece8427-3c58-4a14-9f11-3001fbbda984.png)

