### PR TITLE
Remove import organisations from db:seed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,6 @@ node {
   govuk.buildProject(
     publishingE2ETests: true,
     repoName: 'contacts-admin',
-    beforeTest: {
-      govuk.setEnvar('RUNNING_IN_CI', 'true')
-    },
     brakeman: true,
   )
   // Run against the MySQL 8 Docker instance on GOV.UK CI

--- a/app/tasks/seed_database.rb
+++ b/app/tasks/seed_database.rb
@@ -5,7 +5,8 @@ class SeedDatabase
 
   def run
     create_users
-    create_contact_groups
+    hmrc_organisation = create_hmrc_organisation
+    create_contact_groups(hmrc_organisation)
   end
 
   def create_users
@@ -16,6 +17,17 @@ class SeedDatabase
       u.email = "winston@alphagov.co.uk"
       u.permissions = %w[signin]
     }.save
+  end
+
+  def create_hmrc_organisation
+    # These values should match what Whitehall has stored so that
+    # the publishing end-to-end tests can succeed
+    Organisation.create(
+      title: "HM Revenue & Customs",
+      slug: "hm-revenue-customs",
+      abbreviation: "HMRC",
+      content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+    )
   end
 
   CONTACT_GROUPS = [
@@ -91,7 +103,7 @@ class SeedDatabase
     },
   ].freeze
 
-  def create_contact_groups
+  def create_contact_groups(hmrc_organisation)
     CONTACT_GROUPS.each do |contact_group|
       ContactGroup.find_or_create_by(
         contact_group_type_id: contact_group[:contact_group_type].id,
@@ -100,9 +112,5 @@ class SeedDatabase
         organisation_id: hmrc_organisation.id,
       )
     end
-  end
-
-  def hmrc_organisation
-    Organisation.find_or_create_by(slug: "hm-revenue-customs")
   end
 end

--- a/app/tasks/seed_database.rb
+++ b/app/tasks/seed_database.rb
@@ -10,13 +10,13 @@ class SeedDatabase
   end
 
   def create_users
-    User.new { |u|
-      u.name = "Winston"
-      u.uid = "winston"
-      u.version = 1
-      u.email = "winston@alphagov.co.uk"
-      u.permissions = %w[signin]
-    }.save
+    User.create(
+      name: "Winston",
+      uid: "winston",
+      version: 1,
+      email: "winston@alphagov.co.uk",
+      permissions: %w[signin],
+    )
   end
 
   def create_hmrc_organisation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
-# This env var is set by the beforeTest action in our Jenkinsfile
-unless ENV.key?("RUNNING_IN_CI")
-  # See app/tasks/seed_database
-  SeedDatabase.instance.run
-end
+# The tests expect an empty database
+return if Rails.env.test?
+
+# See app/tasks/seed_database
+SeedDatabase.instance.run

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,5 @@
 # This env var is set by the beforeTest action in our Jenkinsfile
 unless ENV.key?("RUNNING_IN_CI")
   # See app/tasks/seed_database
-  ImportOrganisations.new.call
   SeedDatabase.instance.run
 end


### PR DESCRIPTION
ImportOrganisations.new.call involves pulling data dynamically in from
GOV.UK. This makes it an extremely complicated approach to seeding a
database, and causes a bunch of misery in spinning up a production-like
environment for GOV.UK (as is the case with publishing_e2e_tests [1]) as
you need Whitehall to have published data, that data to make it to
Search API, Router to be running and then Collections running - a heck
of a lot for a db:seed!

It's unclear why this is needed, the SeedDatabase step will create a
single organisation (HMRC) which is probably all that is needed.

This simplifies this just to the more basic seed call.