### PR TITLE
Remove unused contacts file

### DIFF
--- a/app/lib/contacts.rb
+++ b/app/lib/contacts.rb
@@ -1,7 +1,0 @@
-module Contacts
-  autoload :Interactor, "contacts/interactor"
-
-  mattr_accessor :worldwide_api
-  mattr_accessor :organisations_api
-  mattr_accessor :publishing_api
-end


### PR DESCRIPTION
Removing a file that is redundant. Contacts was replaced by Services in [this PR ](https://github.com/alphagov/contacts-admin/commit/437a78aa27f550d4da11bace78dee99d6638ee6c) but it looks like we forgot to remove the contacts.rb file.