### PR TITLE
Remove SHA1 to SHA256 cookie rotation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,20 +62,3 @@ module Contacts
     end
   end
 end
-
-# Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-# TODO: Remove this after existing user sessions have been rotated
-# https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-  salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-  secret_key_base = Rails.application.secrets.secret_key_base
-  next if secret_key_base.blank?
-
-  key_generator = ActiveSupport::KeyGenerator.new(
-    secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-  )
-  key_len = ActiveSupport::MessageEncryptor.key_len
-  secret = key_generator.generate_key(salt, key_len)
-
-  cookies.rotate :encrypted, secret
-end


### PR DESCRIPTION
This has now been deployed to production for a number of weeks, therefore we can remove the code to rotate the cookies that was added in bb4b1653d7bce360a30532c6061c99ae39d43e3f.

[Trello card](https://trello.com/c/nmJc03Gd/249-upgrade-contacts-admin-from-rails-61x-to-70x)