### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ WORKDIR /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app ./
 
-CMD bundle exec puma
+CMD GOVUK_PROMETHEUS_EXPORTER=true bundle exec puma

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
