### PR TITLE
Updating base image to use a new base and builder image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,31 @@
-ARG base_image=ruby:3.0.4
-
-FROM $base_image AS builder
-
-ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.0.4
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.0.4
+ 
+FROM $builder_image AS builder
 
 RUN mkdir /app
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock .ruby-version /app/
+COPY Gemfile* .ruby-version /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install --jobs 4 --retry=2
+RUN bundle install
 
 COPY . /app
-# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_APP_DOMAIN=www.gov.uk \
-    GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-    bundle exec rails assets:precompile
+
+RUN bundle exec rails assets:precompile && rm -fr /app/log
+
 
 FROM $base_image
 
-ENV RAILS_ENV=production GOVUK_APP_NAME=contacts-admin GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=https://www.gov.uk PORT=3051 DATABASE_URL=mysql2://root:root@mysql/contacts-admin
+ENV GOVUK_APP_NAME=contacts-admin PORT=3051 DATABASE_URL=mysql2://root:root@mysql/contacts-admin
 
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
-
-WORKDIR /app
+RUN mkdir /app
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app ./
+COPY --from=builder /app /app/
 
-CMD GOVUK_PROMETHEUS_EXPORTER=true bundle exec puma
+USER app
+WORKDIR /app
+
+CMD bundle exec puma


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)


Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
