### PR TITLE
Small Dockerfile fixes for Replatforming.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+CONTRIBUTING.md
+Jenkinsfile
+README.md
+docs
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.0.4
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.0.4
- 
-FROM $builder_image AS builder
 
-RUN mkdir /app
+FROM $builder_image AS builder
 
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
-
 RUN bundle install
 
 COPY . /app
@@ -19,8 +16,6 @@ RUN bundle exec rails assets:precompile && rm -fr /app/log
 FROM $base_image
 
 ENV GOVUK_APP_NAME=contacts-admin
-
-RUN mkdir /app
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/


### PR DESCRIPTION
Remove an unnecessary `mkdir /app` from the Dockerfile, since this will be incompatible with an upcoming version of govuk-ruby-base.

Also remove some unneeded paths from the image.