### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/app/lib/contacts/distributed_lock.rb
+++ b/app/lib/contacts/distributed_lock.rb
@@ -6,7 +6,7 @@ module Contacts
     LIFETIME = (5 * 60) # seconds. The lock expires automatically after this time
 
     def lock
-      Redis.current.lock("contacts-admin:organisations:import", life: LIFETIME) do
+      Redis.new.lock("contacts-admin:organisations:import", life: LIFETIME) do
         Rails.logger.debug("Successfully got a lock. Running...")
         yield
       end

--- a/spec/lib/contacts/distributed_lock_spec.rb
+++ b/spec/lib/contacts/distributed_lock_spec.rb
@@ -5,12 +5,12 @@ require "redis-lock"
 RSpec.describe "Contacts::DistributedLock" do
   describe "#lock" do
     it "yields the block when a redis lock can be acquired" do
-      expect(Redis.current).to receive(:lock).and_call_original
+      expect_any_instance_of(Redis).to receive(:lock).and_call_original
       expect { |b| Contacts::DistributedLock.new.lock(&b) }.to yield_control
     end
 
     it "silently doesn't a yield the block when a lock can't be acquired" do
-      allow(Redis.current).to receive(:lock).and_raise(Redis::Lock::LockNotAcquired)
+      allow_any_instance_of(Redis).to receive(:lock).and_raise(Redis::Lock::LockNotAcquired)
       expect { |b| Contacts::DistributedLock.new.lock(&b) }.not_to yield_control
     end
   end


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
