### PR TITLE
Revert  "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "active_hash"
 gem "ancestry"
 gem "bootsnap"
 gem "friendly_id"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mlanett-redis-lock"
 gem "mysql2"
 gem "paper_trail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,11 +213,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -483,7 +480,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_schemas
   json-schema
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   mlanett-redis-lock
   mysql2
   paper_trail


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
