### PR TITLE
Clean up Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,14 @@
+.dockerignore
 .git
+.github
 .gitignore
-CONTRIBUTING.md
+Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
 log
+node_modules
 spec
-test
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && rm -fr /app/log
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=contacts-admin
 
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-WORKDIR /app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]


### PR DESCRIPTION
- Parameterise the Ruby version.
- Precompute the [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-) bytecode and path caches so that bootsnap is effective when running the app from the container image.
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.