### PR TITLE
Remove Mailer from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "active_hash"
 gem "ancestry"
 gem "bootsnap"
 gem "friendly_id"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mlanett-redis-lock"
 gem "mysql2"
 gem "paper_trail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,6 @@ DEPENDENCIES
   govuk_app_config
   govuk_schemas
   json-schema
-  mail (~> 2.8.0)
   mlanett-redis-lock
   mysql2
   paper_trail


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
