### PR TITLE
Make schedule.rb empty to remove EC2 cron jobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,1 @@
-# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
-env :PATH, "/usr/local/bin:/usr/bin:/bin"
-
-# We need Rake to use our own environment
-job_type :rake, "cd :path && govuk_setenv contacts bundle exec rake :task :output"
-
-set :output, error: "log/cron.error.log", standard: "log/cron.log"
-
-every :day, at: "3am" do
-  rake "organisations:import"
-end
+# File required to ensure cronjobs are removed


### PR DESCRIPTION
This state is captured in our helm charts and may cause conflict if duplicated in both environments
https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-integration.yaml#L401
