### PR TITLE
Run schema tests against "main" branch of Publishing API 

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,7 +10,7 @@ on:
       publishingApiRef:
         description: 'The branch, tag or SHA to checkout Publishing API'
         required: false
-        default: 'deployed-to-production'
+        default: 'main'
         type: string
 
 jobs:


### PR DESCRIPTION
The concept of the "deployed-to-production" branch no longer exists in GOV.UK infrastructure since we switched to a Kubernetes platform. Thus this branch is stale and no-longer represents the deployed version of Publishing API.

Switching this to "main" means that we will be testing against the version of Publishing API that is expected to be deployed - as Publishing API is continuously deployed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
