### PR TITLE
Update world location code for breaking changes in `gds-api-adapters` version 89.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     ffi (1.15.5)
     friendly_id (5.5.0)
       activerecord (>= 4.0.0)
-    gds-api-adapters (88.2.0)
+    gds-api-adapters (89.0.0)
       addressable
       link_header
       null_logger

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,7 +1,7 @@
 class WorldLocation
   def self.all
     data = Rails.cache.fetch("all", expires_in: 1.day) do
-      Services.worldwide_api.world_locations.with_subsequent_pages.to_a
+      Services.worldwide_api.world_locations.to_a
     end
 
     data
@@ -14,7 +14,6 @@ class WorldLocation
       Services
         .worldwide_api
         .world_location(location_slug)
-        .parsed_content
     end
 
     new(data)

--- a/spec/interactors/admin/clone_contact_spec.rb
+++ b/spec/interactors/admin/clone_contact_spec.rb
@@ -26,4 +26,42 @@ describe Admin::CloneContact do
       end
     end
   end
+
+  def stub_worldwide_api_has_selection_of_locations
+    stub_worldwide_api_has_locations %w[
+      afghanistan
+      angola
+      australia
+      bahamas
+      belarus
+      brazil
+      brunei
+      cambodia
+      chad
+      croatia
+      denmark
+      eritrea
+      france
+      ghana
+      iceland
+      japan
+      laos
+      luxembourg
+      malta
+      micronesia
+      mozambique
+      nicaragua
+      panama
+      portugal
+      sao-tome-and-principe
+      singapore
+      south-korea
+      sri-lanka
+      uk-delegation-to-council-of-europe
+      uk-delegation-to-organization-for-security-and-co-operation-in-europe
+      united-kingdom
+      venezuela
+      vietnam
+    ]
+  end
 end

--- a/spec/models/post_address_spec.rb
+++ b/spec/models/post_address_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
+require "gds_api/test_helpers/worldwide"
 
 RSpec.describe PostAddress, type: :model do
+  include GdsApi::TestHelpers::Worldwide
+
   setup do
-    stub_world_location_api
+    stub_worldwide_api_has_locations(%w[united-kingdom finland])
   end
 
   let(:item) { create(:post_address) }

--- a/spec/models/world_location_spec.rb
+++ b/spec/models/world_location_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
+require "gds_api/test_helpers/worldwide"
 
 describe WorldLocation, type: :model do
+  include GdsApi::TestHelpers::Worldwide
+
   describe ".all" do
     it "returns a list of WorldLocations" do
-      api_response = { "results" => [
-        { "format" => "World location", "details" => { "slug" => "United Kingdom" } },
-        { "format" => "World location", "details" => { "slug" => "Finland" } },
-      ] }.to_json
-      stub_request(:get, "http://www.dev.gov.uk/api/world-locations")
-       .to_return(status: 200, body: api_response, headers: {})
+      stub_worldwide_api_has_locations(%w[united-kingdom finland])
 
       locations = WorldLocation.all
       expect(locations.length).to be 2
-      expect(locations.first.slug).to eq "United Kingdom"
-      expect(locations.last.slug).to eq "Finland"
+      expect(locations.first.slug).to eq "united-kingdom"
+      expect(locations.first.title).to eq "United Kingdom"
+      expect(locations.last.slug).to eq "finland"
+      expect(locations.last.title).to eq "Finland"
     end
   end
 

--- a/spec/presenters/post_addresses_presenter_spec.rb
+++ b/spec/presenters/post_addresses_presenter_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
+require "gds_api/test_helpers/worldwide"
 
 describe PostAddressesPresenter do
+  include GdsApi::TestHelpers::Worldwide
+
   let(:post) { create :post_address, description: "post description" }
 
   it "transforms a contact to the correct format" do
-    stub_world_location_api
+    stub_worldwide_api_has_locations(%w[united-kingdom finland])
 
     presented = PostAddressesPresenter.new([post]).present.first
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,8 +34,3 @@ RSpec.configure do |config|
   config.include FeaturesHelpers, type: :feature
   config.include FileCreationHelper
 end
-
-def stub_world_location_api
-  stub_request(:get, "#{Plek.website_root}/api/world-locations/united-kingdom")
-    .to_return(status: 200, body: "{}")
-end


### PR DESCRIPTION
This version of `gds-api-adapters` removes pagination of the world locations, so we need to update this application accordingly.

[Trello card](https://trello.com/c/4r5uSD2R)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
