### PR TITLE
Add Google Tag Manager snippet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "gds-sso"
 gem "govspeak"
 gem "govuk_admin_template"
 gem "govuk_app_config"
+gem "govuk_publishing_components"
 gem "plek"
 
 # assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,6 +691,7 @@ DEPENDENCIES
   govspeak
   govuk_admin_template
   govuk_app_config
+  govuk_publishing_components
   govuk_schemas
   json-schema
   mlanett-redis-lock

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,6 +8,8 @@
   <%= yield :extra_headers %>
 <% end %>
 
+<% render "layouts/google_tag_manager" %>
+
 <% content_for :navbar_items do %>
   <li class="<%= 'active' if params[:controller] == 'admin/contacts' || params[:controller] == 'admin/contacts/contact_form_links' || params[:controller] == 'admin/contacts/email_addresses' || params[:controller] == 'admin/contacts/phone_numbers' || params[:controller] == 'admin/contacts/post_addresses' %>">
     <%= link_to 'Contacts', admin_contacts_path  %>


### PR DESCRIPTION
Google Tag Manager (GTM) can be included on all pages of the app by configuring the following environment variables:

GOOGLE_TAG_MANAGER_ID
GOOGLE_TAG_MANAGER_AUTH
GOOGLE_TAG_MANAGER_PREVIEW
All three variables are optional.

If none are set, GTM will not be included on the page.

If only GOOGLE_TAG_MANAGER_ID is set, the default environment of the GTM container will be used.

If GOOGLE_TAG_MANAGER_AUTH and GOOGLE_TAG_MANAGER_PREVIEW are set, the specified GTM container environment will be used. This is used for managing the rollout of changes to integration so they can be tested before rolling out to production.

Trello card: https://trello.com/c/Wcuq3R1S/2167-add-ga4-page-view-tracking-to-apps-that-we-own
