### PR TITLE
Migrate to dartsass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ public/assets
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "govuk_publishing_components"
 gem "plek"
 
 # assets
-gem "sass-rails"
+gem "dartsass-rails"
 gem "select2-rails"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.3.4)
     debug_inspector (1.1.0)
     descendants_tracker (0.0.4)
@@ -627,16 +630,17 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass-embedded (1.70.0)
+      google-protobuf (~> 3.25)
+      rake (>= 13.0.0)
+    sass-embedded (1.70.0-aarch64-linux-gnu)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm64-darwin)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     searchlight (4.1.0)
     select2-rails (4.0.13)
     sentry-rails (5.16.1)
@@ -669,7 +673,6 @@ GEM
     stringio (3.1.0)
     thor (1.3.0)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -714,6 +717,7 @@ DEPENDENCIES
   brakeman
   capybara
   climate_control
+  dartsass-rails
   factory_bot_rails
   fakefs
   friendly_id
@@ -734,7 +738,6 @@ DEPENDENCIES
   rails (= 7.1.3)
   rspec-rails
   rubocop-govuk
-  sass-rails
   searchlight
   select2-rails
   shoulda-matchers

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,10 +34,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Rather than use a CSS compressor, use the SASS style to perform compression.
-  config.sass.style = :compressed
-  config.sass.line_comments = false
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,5 @@
+Rails.application.config.dartsass.builds = {
+  "admin.scss" => "application.css",
+}
+
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
## Description 

LibSass has been deprecated. We're moving to Dart Sass. This follows the upgrade guide found here
https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

I've deployed and tested this on integration.

## Trello card

https://trello.com/c/qeNHFPZN/1667-migrate-to-dart-sass

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
