### PR TITLE
Revert govuk_publishing_components major version bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "gds-sso"
 gem "govspeak"
 gem "govuk_admin_template"
 gem "govuk_app_config"
-gem "govuk_publishing_components"
+gem "govuk_publishing_components", "39.2.5"
 gem "plek"
 
 # assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (43.1.1)
+    govuk_publishing_components (39.2.5)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -747,7 +747,7 @@ DEPENDENCIES
   govspeak
   govuk_admin_template
   govuk_app_config
-  govuk_publishing_components
+  govuk_publishing_components (= 39.2.5)
   govuk_schemas
   json-schema
   mlanett-redis-lock


### PR DESCRIPTION
Despite the tests passing in #1439, the deployment failed in https://github.com/alphagov/contacts-admin/actions/runs/10166486149 with:

```
[builder 7/7] RUN rails assets:precompile && rm -fr log
0.106 INFO: with_tmpdir_for_ruby: execing rails with TMPDIR=/tmp/ruby-app-xGCNAKnA
1.525 I, [2024-07-30T17:53:13.769638 #7]  INFO -- : govuk_app_config changing time_zone from UTC (the default) to London
10.13 bin/rails aborted!
10.13 Uglifier::Error: Name expected (Uglifier::Error)
10.13 --
10.13  33111   window.GOVUK.modules.start()
10.13  33112 });
10.13  33113 (function (global, factory) {
10.13  33114   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
10.13  33115   typeof define === 'function' && define.amd ? define(['exports'], factory) :
10.13  33116   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.GOVUKFrontend = {}));
10.13  33117 })(this, (function (exports) { 'use strict';
10.13  33118
10.13     =>   function mergeConfigs(...configObjects) {
```

Reverting so that deployment works again as normal, and we can investigate bumping govuk_publishing_components again later.

---

Trello: https://trello.com/c/vbqszQXq/2762-update-publishing-apps-to-govukpublishingcomponents-v4000

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
