### PR TITLE
Upgrade to govuk_publishing_components 43.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,13 @@ gem "gds-sso"
 gem "govspeak"
 gem "govuk_admin_template"
 gem "govuk_app_config"
-gem "govuk_publishing_components", "39.2.5"
+gem "govuk_publishing_components", "43.1.1"
 gem "plek"
 
 # assets
 gem "dartsass-rails"
 gem "select2-rails"
-gem "uglifier"
+gem "terser"
 
 # development
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (43.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -690,13 +690,13 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.1)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     thread_safe (0.3.6)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     useragent (0.16.10)
@@ -747,7 +747,7 @@ DEPENDENCIES
   govspeak
   govuk_admin_template
   govuk_app_config
-  govuk_publishing_components (= 39.2.5)
+  govuk_publishing_components (= 43.1.1)
   govuk_schemas
   json-schema
   mlanett-redis-lock
@@ -765,7 +765,7 @@ DEPENDENCIES
   simple_form
   simplecov
   sprockets-rails
-  uglifier
+  terser
   virtus
   webmock
   whenever

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,8 +25,8 @@ Rails.application.configure do
 
   # Compress JavaScript.
   # Fix for ie8 and select2
-  require "uglifier"
-  config.assets.js_compressor = Uglifier.new(output: { ascii_only: true, quote_keys: true })
+  config.assets.js_compressor = :terser
+  config.assets.terser = { output: { ascii_only: true, quote_keys: true } }
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
This is effectively an upgrade to GOV.UK Frontend 5.

This is another attempt at making the upgrade. We've just reverted in [PR #1467](https://github.com/alphagov/contacts-admin/pull/1467). 
Current changes include replacing `Uglifier` with `Terser` as per the documentation [here](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
