### PR TITLE
Allow auto-merging of patch versions of Rails

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -6,5 +6,6 @@ defaults:
   auto_merge: true
   update_external_dependencies: true
 overrides:
-  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
-    auto_merge: false
+  - dependency: rails
+    allowed_semver_bumps:
+      - patch # minor/major bumps should be upgraded manually. See https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails


### PR DESCRIPTION
Our [docs](https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails) suggest it is safe to auto-merge provided the tests pass. This will help to disambiguate Rails PRs going forward, as any PRs that are not auto-merged require manual intervention (currently it’s always a bit uncertain).

Trello: https://trello.com/c/AlWoQfl0/2859-allow-auto-merging-of-patch-versions-of-rails

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
