### PR TITLE
Remove unused `format_name` property

### DIFF
--- a/app/services/publish_finders.rb
+++ b/app/services/publish_finders.rb
@@ -51,7 +51,6 @@ private
           "format": "contact",
           "organisations": %w[hm-revenue-customs],
         },
-        "format_name": "Contact HM Revenue & Customs",
         "show_summaries": true,
       },
       "routes": [


### PR DESCRIPTION
See https://github.com/alphagov/specialist-publisher/pull/2998

Trello: https://trello.com/c/ZiFU2o6B

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
