### PR TITLE
Mount /component-guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   # Permanently redirect any requests for the root URL to /admin
   root to: redirect("/admin", status: 301)
 
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
+
   namespace :admin do
     root to: "contacts#index", via: :get
 


### PR DESCRIPTION
This should be enabled on every app which pulls in govuk_publishing_components.

Trello: https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
