### PR TITLE
Add rake task for redirecting the legacy Legal Aid Agency contact

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -30,4 +30,22 @@ namespace :migrate do
       discard_drafts: true,
     )
   end
+
+  desc "This rake task sets up a redirect from the legacy
+  `/government/organisations/legal-aid-agency/contact/legal-aid-agency-customer-services`
+  route to the agreed replacement for that route: the Legal Aid Agency
+  homepage (`/government/organisations/legal-aid-agency`).
+
+  It also deletes the corresponding Contact."
+  task legal_aid_agency_contact: :environment do
+    Services.publishing_api.unpublish(
+      "7d46f9b4-0a6a-4598-afb8-07f437fe4de6",
+      type: "redirect",
+      explanation: "Deprecated the Legal Aid Agency Customer Services contact to retire Contacts Admin.",
+      alternative_path: "/government/organisations/legal-aid-agency",
+      discard_drafts: true,
+    )
+
+    Contact.find_by(slug: "legal-aid-agency-customer-services").destroy!
+  end
 end


### PR DESCRIPTION
Adds the following task, to apply a redirect from the legacy Legal Aid Agency contact to its homepage, as agreed with the stakeholder:

```
rake contacts-admin migrate:legal_aid_agency_contact
```

No 'Danger' note added to the description of this one, since it can be executed any time (we're not blocked on anything).

Trello: https://trello.com/c/5tPgPNhN

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
